### PR TITLE
Update config files and include a folder for testing

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,20 +10,11 @@
 			"type": "extensionHost",
 			"request": "launch",
 			"runtimeExecutable": "${execPath}",
-			"args": [],
-			"linux": {
-				"args": [
-					"--extensionDevelopmentPath=${workspaceFolder}",
-					"${workspaceFolder}/../hiwijob/v0"
-				]
-			},
-			"windows": {
-				"args": [
-					"--disable-extensions",
-					"--extensionDevelopmentPath=${workspaceFolder}",
-					"${workspaceFolder}/../vscode-R-test"
-				]
-			},
+			"args": [
+				"--disable-extensions",
+				"--extensionDevelopmentPath=${workspaceFolder}",
+				"${workspaceFolder}/test/R"
+			],
 			"outFiles": [
 				"${workspaceFolder}/out/**/*.js"
 			],

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
         "rdebugger.rterm.mac": {
           "type": "string",
           "default": "/usr/local/bin/R",
-          "description": "R path for Mac OS X"
+          "description": "R path for macOS"
         },
         "rdebugger.rterm.linux": {
           "type": "string",
@@ -143,8 +143,8 @@
         },
         "rdebugger.terminal.mac": {
           "type": "string",
-          "default": "Terminal.app",
-          "description": "Terminal path for Mac OS X"
+          "default": "/bin/bash",
+          "description": "Terminal path for macOS"
         },
         "rdebugger.terminal.linux": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -124,57 +124,57 @@
         "rdebugger.rterm.windows": {
           "type": "string",
           "default": "\"C:\\Program Files\\R\\R-3.6.3\\bin\\R.exe\"",
-          "description": "R.exe path for windows"
+          "description": "R.exe path for Windows."
         },
         "rdebugger.rterm.mac": {
           "type": "string",
           "default": "/usr/local/bin/R",
-          "description": "R path for macOS"
+          "description": "R path for macOS."
         },
         "rdebugger.rterm.linux": {
           "type": "string",
           "default": "/usr/bin/R",
-          "description": "R path for Linux"
+          "description": "R path for Linux."
         },
         "rdebugger.terminal.windows": {
           "type": "string",
           "default": "C:\\Windows\\System32\\cmd.exe",
-          "description": "Terminal path for windows (e.g. cmd.exe)"
+          "description": "Terminal path for windows (e.g. cmd.exe)."
         },
         "rdebugger.terminal.mac": {
           "type": "string",
           "default": "/bin/bash",
-          "description": "Terminal path for macOS"
+          "description": "Terminal path for macOS."
         },
         "rdebugger.terminal.linux": {
           "type": "string",
           "default": "/bin/bash",
-          "description": "Terminal path for Linux"
+          "description": "Terminal path for Linux."
         },
         "rdebugger.useRCommandQueue": {
           "type": "boolean",
           "default": true,
-          "description": "Whether to queue R commands and send them only if the R-process is idle"
+          "description": "Whether to queue R commands and send them only if the R-process is idle."
         },
         "rdebugger.waitBetweenRCommands": {
           "type": "integer",
           "default": 10,
-          "description": "The time (in ms) to wait between R commands"
+          "description": "The time (in ms) to wait between R commands."
         },
         "rdebugger.overwritePrint": {
           "type": "boolean",
           "default": true,
-          "description": "Whether to write a new print() function to .GlobalEnv (direct calls to base::print are not affected)"
+          "description": "Whether to write a new print() function to .GlobalEnv (direct calls to base::print are not affected)."
         },
         "rdebugger.overwriteCat": {
           "type": "boolean",
           "default": true,
-          "description": "Whether to write a new cat() function to .GlobalEnv (direct calls to base::cat are not affected)"
+          "description": "Whether to write a new cat() function to .GlobalEnv (direct calls to base::cat are not affected)."
         },
         "rdebugger.overwriteSource": {
           "type": "boolean",
           "default": true,
-          "description": "Whether to write a new source() function to .GlobalEnv (direct calls to base::source are not affected)"
+          "description": "Whether to write a new source() function to .GlobalEnv (direct calls to base::source are not affected)."
         },
         "rdebugger.setBreakpointsInPackages": {
           "type": "boolean",

--- a/test/R/.vscode/launch.json
+++ b/test/R/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "R-Debugger",
+      "request": "launch",
+      "name": "R Debugger",
+      "program": "${file}",
+      "debugFunction": false,
+      "allowGlobalDebugging": true
+    }
+  ]
+}

--- a/test/R/test.R
+++ b/test/R/test.R
@@ -1,0 +1,16 @@
+foo <- function(x, y) {
+  print(x)
+  print(y)
+  x + y
+}
+
+bar <- function(x, n) {
+  z <- x
+  for (i in seq_len(n)) {
+    print(i)
+    z <- foo(z, x)
+  }
+  z
+}
+
+bar(2, 5)


### PR DESCRIPTION
This PR makes changes to `launch.json` so that it is easier for other contributors to work with under Windows, macOS and Linux.

I also change the default of `rdebugger.terminal.mac` to `/bin/bash` as `Terminal.app` does not seem to work.

Also, a minimal testing project in R is included so that developers could share the testing script when launching the extension.