### PR TITLE
Use registry and PATH to find R executable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1893,6 +1893,11 @@
 				}
 			}
 		},
+		"winreg": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/winreg/-/winreg-1.2.4.tgz",
+			"integrity": "sha1-ugZWKbepJRMOFXeRCM9UCZDpjRs="
+		},
 		"word-wrap": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
       "properties": {
         "rdebugger.rterm.windows": {
           "type": "string",
-          "default": "\"C:\\Program Files\\R\\R-3.6.3\\bin\\R.exe\"",
+          "default": "",
           "description": "R.exe path for Windows."
         },
         "rdebugger.rterm.mac": {

--- a/package.json
+++ b/package.json
@@ -207,6 +207,7 @@
   },
   "dependencies": {
     "await-notify": "1.0.1",
-    "vscode-debugadapter": "^1.40.0"
+    "vscode-debugadapter": "^1.40.0",
+    "winreg": "^1.2.4"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,8 @@ This extension adds debugging capabilities for the R programming language.
 ## Using the Debugger
 * Install the **R Debugger** extension in VS Code.
 * Install the **vscDebugger** package in R (https://github.com/ManuelHentschel/vscDebugger).
-* Make sure the settings `rdebugger.rterm.XXX` and `rdebugger.terminal.XXX` contain valid paths to R and a terminal program
+* Make sure the settings `rdebugger.terminal.*` contain valid path to terminal program.
+* If your R path is neither in Windows registry nor in `PATH` environment variable, make sure to provide valid R path in `rdebugger.rterm.*`.
 * Press F5 and select `R Debugger` as debugger. With the default launch configuration, the debugger will start a new R session.
 * To run a file, focus the file in the editor and press F5 (or the continue button in the debug controls)
 * Output will be printed to the debug console, expressions entered into the debug console are evaluated in the currently active frame

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,7 @@ This extension adds debugging capabilities for the R programming language.
 * To run a file, focus the file in the editor and press F5 (or the continue button in the debug controls)
 * Output will be printed to the debug console, expressions entered into the debug console are evaluated in the currently active frame
 
+*For Windows users: If your R installation is from [CRAN](http://cran.r-project.org/mirrors.html) with default installation settings, especially **Save version number in registry** is enabled, then there's no need to specify `rdebugger.rterm.windows`.*
 
 ## Installation
 The VS code extension can be run from source by opening the project repo's root directory in vscode and pressing F5.

--- a/src/debugRuntime.ts
+++ b/src/debugRuntime.ts
@@ -129,7 +129,7 @@ export class DebugRuntime extends EventEmitter {
 
 		// start R in child process
 		const terminalPath = getTerminalPath(); // read OS-specific terminal path from config
-		const rPath = getRPath(); // read OS-specific R path from config
+		const rPath = await getRPath(); // read OS-specific R path from config
 		const cwd = path.dirname(program);
 		const rArgs = ['--ess', '--quiet', '--interactive', '--no-save']; 
 		// (essential R args: --interactive (linux) and --ess (windows) to force an interactive session)

--- a/src/debugRuntime.ts
+++ b/src/debugRuntime.ts
@@ -7,7 +7,7 @@ import { EventEmitter } from 'events';
 // import { Terminal, window } from 'vscode';
 import * as vscode from 'vscode';
 import { workspace } from 'vscode';
-import {getRPath, getTerminalPath, escapeForRegex } from "./utils";
+import { config, getRPath, getTerminalPath, escapeForRegex } from "./utils";
 import { isUndefined } from 'util';
 
 import { RSession, makeFunctionCall, anyRArgs, escapeStringForR } from './rSession';
@@ -111,9 +111,8 @@ export class DebugRuntime extends EventEmitter {
 		// LAUNCH R PROCESS
 
 		// read settings from vsc-settings
-		const config = workspace.getConfiguration('rdebugger');
-		this.useRCommandQueue = config.get<boolean>('useRCommandQueue', true);
-		this.waitBetweenRCommands = config.get<number>('waitBetweenRCommands', 0);
+		this.useRCommandQueue = config().get<boolean>('useRCommandQueue', true);
+		this.waitBetweenRCommands = config().get<number>('waitBetweenRCommands', 0);
 
 		// print some info about the rSession
 		// everything following this is printed in (collapsed) group
@@ -199,9 +198,9 @@ export class DebugRuntime extends EventEmitter {
 		this.rSession.defaultLibrary = this.packageName;
 
 		// get config about overwriting R functions
-		const overwritePrint = config.get<boolean>('overwritePrint', false);
-		const overwriteCat = config.get<boolean>('overwriteCat', false);
-		const overwriteSource = config.get<boolean>('overwriteSource', false);
+		const overwritePrint = config().get<boolean>('overwritePrint', false);
+		const overwriteCat = config().get<boolean>('overwriteCat', false);
+		const overwriteSource = config().get<boolean>('overwriteSource', false);
 
 		// prep r session
 		const options = {
@@ -220,7 +219,7 @@ export class DebugRuntime extends EventEmitter {
 		);
 		this.rSession.callFunction('.vsc.prepGlobalEnv', options);
 
-		this.setBreakpointsInPackages = config.get<boolean>('setBreakpointsInPackages', false);
+		this.setBreakpointsInPackages = config().get<boolean>('setBreakpointsInPackages', false);
 
 		this.endOutputGroup();
 	}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,8 +3,10 @@ import { window, workspace } from "vscode";
 import path = require("path");
 import fs = require("fs");
 import winreg = require("winreg");
-const config = workspace.getConfiguration("rdebugger");
 
+export function config() {
+    return workspace.getConfiguration("rdebugger");
+}
 
 function getRfromEnvPath(platform: string) {
     let splitChar: string = ":";
@@ -30,7 +32,7 @@ export async function getRPath() {
     const platform: string = process.platform;
 
     if (platform === "win32") {
-        rpath = config.get<string>("rterm.windows", "");
+        rpath = config().get<string>("rterm.windows", "");
         if (rpath === "") {
             // Find path from registry
             try {
@@ -46,9 +48,9 @@ export async function getRPath() {
             }
         }
     } else if (platform === "darwin") {
-        rpath = config.get<string>("rterm.mac", "");
+        rpath = config().get<string>("rterm.mac", "");
     } else if (platform === "linux") {
-        rpath = config.get<string>("rterm.linux", "");
+        rpath = config().get<string>("rterm.linux", "");
     }
 
     if (rpath === "") {
@@ -63,13 +65,13 @@ export async function getRPath() {
 
 export function getTerminalPath() {
     if (process.platform === "win32") {
-        return config.get<string>("terminal.windows", "");
+        return config().get<string>("terminal.windows", "");
     }
     if (process.platform === "darwin") {
-        return config.get<string>("terminal.mac", "");
+        return config().get<string>("terminal.mac", "");
     }
     if (process.platform === "linux") {
-        return config.get<string>("terminal.linux", "");
+        return config().get<string>("terminal.linux", "");
     }
     window.showErrorMessage(`${process.platform} can't find Terminal`);
     return "";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,18 +1,61 @@
 
 import { window, workspace } from "vscode";
-// let config = workspace.getConfiguration();
-const config = workspace.getConfiguration('rdebugger');
+import path = require("path");
+import fs = require("fs");
+import winreg = require("winreg");
+const config = workspace.getConfiguration("rdebugger");
 
 
-export function getRPath() {
-    if (process.platform === "win32") {
-        return config.get<string>("rterm.windows", "R");
+function getRfromEnvPath(platform: string) {
+    let splitChar: string = ":";
+    let fileExtension: string = "";
+
+    if (platform === "win32") {
+        splitChar = ";";
+        fileExtension = ".exe";
     }
-    if (process.platform === "darwin") {
-        return config.get<string>("rterm.mac", "");
+
+    const os_paths: string[] | string = process.env.PATH.split(splitChar);
+    for (const os_path of os_paths) {
+        const os_r_path: string = path.join(os_path, "R" + fileExtension);
+        if (fs.existsSync(os_r_path)) {
+            return os_r_path;
+        }
     }
-    if (process.platform === "linux") {
-        return config.get<string>("rterm.linux", "");
+    return "";
+}
+
+export async function getRPath() {
+    let rpath: string = "";
+    const platform: string = process.platform;
+
+    if (platform === "win32") {
+        rpath = config.get<string>("rterm.windows", "");
+        if (rpath === "") {
+            // Find path from registry
+            try {
+                const key = new winreg({
+                    hive: winreg.HKLM,
+                    key: "\\Software\\R-Core\\R",
+                });
+                const item: winreg.RegistryItem = await new Promise((c, e) =>
+                    key.get("InstallPath", (err, result) => err === null ? c(result) : e(err)));
+                rpath = path.join(item.value, "bin", "R.exe");
+            } catch (e) {
+                rpath = "";
+            }
+        }
+    } else if (platform === "darwin") {
+        rpath = config.get<string>("rterm.mac", "");
+    } else if (platform === "linux") {
+        rpath = config.get<string>("rterm.linux", "");
+    }
+
+    if (rpath === "") {
+        rpath = getRfromEnvPath(platform);
+    }
+    if (rpath !== "") {
+        return rpath;
     }
     window.showErrorMessage(`${process.platform} can't find R`);
     return "";


### PR DESCRIPTION
Close #6 

Consistent with vscode-R behavior:

For Windows, if `rterm.windows` is empty, then find registry first, and then PATH.
For macOS and Linux, if `rterm.linux`/`rterm.mac` is empty, find PATH.

This PR also makes use of `config()` so that whenver user changes settings, the config takes effect immediately without having to reload.