### PR TITLE
Add Run Extension without --disable-extensions to launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,6 +11,21 @@
 			"request": "launch",
 			"runtimeExecutable": "${execPath}",
 			"args": [
+				"--extensionDevelopmentPath=${workspaceFolder}",
+				"${workspaceFolder}/test/R"
+			],
+			"outFiles": [
+				"${workspaceFolder}/out/**/*.js"
+			],
+			"smartStep": true,
+			"preLaunchTask": "npm:watch"
+		},
+		{
+			"name": "Run Extension (others disabled)",
+			"type": "extensionHost",
+			"request": "launch",
+			"runtimeExecutable": "${execPath}",
+			"args": [
 				"--disable-extensions",
 				"--extensionDevelopmentPath=${workspaceFolder}",
 				"${workspaceFolder}/test/R"


### PR DESCRIPTION
This PR renames the original `Run Extension` to `Run Extension (others disabled)`, and adds `Run Extension` without `--disable-extensions` (so that vscode-R, vscode-r-lsp, and languageserver could work) with the test scripts.