### PR TITLE
Define VSCODE_DEBUG_SESSION in spawnChildProcess

### DIFF
--- a/src/rSession.ts
+++ b/src/rSession.ts
@@ -286,9 +286,12 @@ function convertToUnnamedArg(arg: unnamedRArg|rList): unnamedRArg{
 /////////////////////////////////
 // Child Process
 
-function spawnChildProcess(terminalPath: string, cwd: string, cmdArgs: string[]=[], logLevel=3){
+function spawnChildProcess(terminalPath: string, cwd: string, cmdArgs: string[] = [], logLevel=3){
     const options = {
-        cwd: cwd
+        cwd: cwd,
+        env: {
+            VSCODE_DEBUG_SESSION: "1",
+        }
     };
     const cp = child.spawn(terminalPath, cmdArgs, options);
 


### PR DESCRIPTION
Close #15 

`VSCODE_DEBUG_SESSION` is set as an environment variables in the terminal process so that the R session could know it is inside a debug session.
