### PR TITLE
Use shell option for child process

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,21 +136,6 @@
           "default": "/usr/bin/R",
           "description": "R path for Linux."
         },
-        "rdebugger.terminal.windows": {
-          "type": "string",
-          "default": "C:\\Windows\\System32\\cmd.exe",
-          "description": "Terminal path for windows (e.g. cmd.exe)."
-        },
-        "rdebugger.terminal.mac": {
-          "type": "string",
-          "default": "/bin/bash",
-          "description": "Terminal path for macOS."
-        },
-        "rdebugger.terminal.linux": {
-          "type": "string",
-          "default": "/bin/bash",
-          "description": "Terminal path for Linux."
-        },
         "rdebugger.useRCommandQueue": {
           "type": "boolean",
           "default": true,

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,6 @@ This extension adds debugging capabilities for the R programming language to Vis
 ## Using the Debugger
 * Install the **R Debugger** extension in VS Code.
 * Install the **vscDebugger** package in R (https://github.com/ManuelHentschel/vscDebugger).
-* Make sure the settings `rdebugger.terminal.*` contain valid path to terminal program.
 * If your R path is neither in Windows registry nor in `PATH` environment variable, make sure to provide valid R path in `rdebugger.rterm.*`.
 * Press F5 and select `R Debugger` as debugger. With the default launch configuration, the debugger will start a new R session.
 * To run a file, focus the file in the editor and press F5 (or the continue button in the debug controls)
@@ -50,8 +49,7 @@ The debugger includes the following features:
 
 ## How it works
 The debugger works as follows:
-* A child process running a terminal application (bash, cmd.exe, ...) is started
-* An R process is started inside the child process
+* An R process is started inside a child process
 * The R package `vscDebugger` is loaded.
 * The Debugger starts and controls R programs by sending input to stdin of the child process
 * After each step, function call etc., the debugger calls functions from the package `vscDebugger` to get info about the stack/variables

--- a/src/debugRuntime.ts
+++ b/src/debugRuntime.ts
@@ -7,7 +7,7 @@ import { EventEmitter } from 'events';
 // import { Terminal, window } from 'vscode';
 import * as vscode from 'vscode';
 import { workspace } from 'vscode';
-import { config, getRPath, getTerminalPath, escapeForRegex } from "./utils";
+import { config, getRPath, escapeForRegex } from "./utils";
 import { isUndefined } from 'util';
 
 import { RSession, makeFunctionCall, anyRArgs, escapeStringForR } from './rSession';
@@ -127,24 +127,22 @@ export class DebugRuntime extends EventEmitter {
 		);
 
 		// start R in child process
-		const terminalPath = getTerminalPath(); // read OS-specific terminal path from config
 		const rPath = await getRPath(); // read OS-specific R path from config
 		const cwd = path.dirname(program);
 		const rArgs = ['--ess', '--quiet', '--interactive', '--no-save']; 
 		// (essential R args: --interactive (linux) and --ess (windows) to force an interactive session)
 
 		this.writeOutput(''
-			+ 'terminalPath: ' + terminalPath
-			+ '\ncwd: ' + cwd
+			+ 'cwd: ' + cwd
 			+ '\nrPath: ' + rPath
 			+ '\nrArgs: ' + rArgs.join(' ')
 		);
 
 		const thisDebugRuntime = this; // direct callback to this.handleLine() does not seem to work...
-		this.rSession = new RSession(terminalPath, rPath, cwd, rArgs, thisDebugRuntime);
+		this.rSession = new RSession(rPath, cwd, rArgs, thisDebugRuntime);
 		this.rSession.waitBetweenCommands = this.waitBetweenRCommands;
 		if(!this.rSession.successTerminal){
-            vscode.window.showErrorMessage('Terminal path not working:\n' + terminalPath);
+            vscode.window.showErrorMessage('Failed to spawn a child process!');
 			this.terminate();
 			return;
 		}

--- a/src/pseudoTerminal.ts
+++ b/src/pseudoTerminal.ts
@@ -1,7 +1,7 @@
 
 import * as child from 'child_process';
 import * as vscode from 'vscode';
-import { getRPath, getTerminalPath } from './utils';
+import { getRPath } from './utils';
 
 // var pty:vscode.Pseudoterminal = {
 //     onDidWrite = new Event<string> 

--- a/src/rSession.ts
+++ b/src/rSession.ts
@@ -31,7 +31,7 @@ export class RSession {
     private restOfStdout: string='';
 
 
-    constructor(terminalPath:string, rPath: string, cwd: string, rArgs: string[]=[],
+    constructor(rPath: string, cwd: string, rArgs: string[]=[],
         // handleLine: (line:string,fromStderr:boolean,isFullLine:boolean)=>(Promise<string>),
         debugRuntime: DebugRuntime,
         logLevel=undefined, logLevelCP=undefined)
@@ -45,7 +45,7 @@ export class RSession {
             this.logLevelCP = logLevelCP;
         }
 
-        this.cp = spawnChildProcess(terminalPath, cwd, [], this.logLevelCP);
+        this.cp = spawnRProcess(rPath, cwd, rArgs, this.logLevelCP);
 
         if(this.cp.pid === undefined){
             this.successTerminal = false;
@@ -64,8 +64,6 @@ export class RSession {
 			this.handleData(data, true);
 		});
 
-        // start R in terminal process
-        this.runCommand(rPath, rArgs);
 
         this.successTerminal = true;
     }
@@ -285,14 +283,16 @@ function convertToUnnamedArg(arg: unnamedRArg|rList): unnamedRArg{
 /////////////////////////////////
 // Child Process
 
-function spawnChildProcess(terminalPath: string, cwd: string, cmdArgs: string[] = [], logLevel=3){
+function spawnRProcess(rPath: string, cwd: string, rArgs: string[] = [], logLevel=3){
     const options = {
         cwd: cwd,
         env: {
             VSCODE_DEBUG_SESSION: "1",
-        }
+        },
+        shell: true
     };
-    const cp = child.spawn(terminalPath, cmdArgs, options);
+
+    const cp = child.spawn(rPath, rArgs, options);
 
     // log output to console.log:
     if(logLevel>=4){

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -64,21 +64,6 @@ export async function getRPath() {
     return "";
 }
 
-export function getTerminalPath() {
-    if (process.platform === "win32") {
-        return config().get<string>("terminal.windows", "");
-    }
-    if (process.platform === "darwin") {
-        return config().get<string>("terminal.mac", "");
-    }
-    if (process.platform === "linux") {
-        return config().get<string>("terminal.linux", "");
-    }
-    window.showErrorMessage(`${process.platform} can't find Terminal`);
-    return "";
-}
-
-
 export function escapeForRegex(text: string): string {
   return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
 }


### PR DESCRIPTION
Uses the shell option to spawn a child process as suggested in https://github.com/ManuelHentschel/VSCode-R-Debugger/issues/15#issue-627859128.

Removes the need to specify a terminal path in the config.