### PR TITLE
Changed setting of environment variables

### DIFF
--- a/src/rSession.ts
+++ b/src/rSession.ts
@@ -288,6 +288,7 @@ function spawnRProcess(rPath: string, cwd: string, rArgs: string[] = [], logLeve
         cwd: cwd,
         env: {
             VSCODE_DEBUG_SESSION: "1",
+            ...process.env
         },
         shell: true
     };


### PR DESCRIPTION
Fixes https://github.com/ManuelHentschel/vscDebugger/issues/17#issuecomment-636467323 by appending the default environment variables to the custom ones.

Windows: default env variables get appended by default
Ubuntu: The fix works to get e.g. `Sys.getenv("HOME")` working
MacOS: ???