### PR TITLE
Add '@' to completion triggers

### DIFF
--- a/src/debugSession.ts
+++ b/src/debugSession.ts
@@ -167,7 +167,7 @@ export class DebugSession extends LoggingDebugSession {
 
 		// make VS Code to support completion in REPL
 		response.body.supportsCompletionsRequest = true;
-		response.body.completionTriggerCharacters = [ "[", "$", ":" ];
+		response.body.completionTriggerCharacters = [ "[", "$", ":", "@" ];
 
 		// make VS Code to send cancelRequests
 		response.body.supportsCancelRequest = true;


### PR DESCRIPTION
Support S4 completion trigger `@`.

See https://github.com/ManuelHentschel/vscDebugger/pull/36.