### PR TITLE
Debug config

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,40 +52,35 @@
         "configurationAttributes": {
           "launch": {
             "required": [
-              "debugFunction",
-              "debugFile",
+              "debugMode",
               "allowGlobalDebugging"
             ],
             "properties": {
-              "program": {
+              "debugMode": {
                 "type": "string",
-                "description": "Absolute path to an R file",
-                "default": "${file}"
+                "enum": ["function","file","workspace"],
+                "description": "Debug a single main-FUNCTION, run an R FILE, or just start an empty R WORKSPACE",
+                "default": "file"
               },
               "workingDirectory": {
                 "type": "string",
                 "description": "Absolute path to a directory.",
                 "default": "${workspaceFolder}"
               },
-              "debugFunction": {
-                "type": "boolean",
-                "default": false,
-                "description": "Whether to debug a single function (called after sourcing the debugged program/R-file)."
-              },
-              "debugFile": {
-                "type": "boolean",
-                "default": false,
-                "description": "Whether to debug the R code contained in a R-file."
+              "file": {
+                "type": "string",
+                "description": "Absolute path to an R file",
+                "default": "${file}"
               },
               "mainFunction": {
                 "type": "string",
                 "default": "main",
-                "description": "The name of the main function, a single function is being debugged. Must be callable without arguments."
+                "description": "The name of the main function, if a single function is being debugged. Must be callable without arguments."
               },
               "allowGlobalDebugging": {
                 "type": "boolean",
                 "default": true,
-                "description": "Whether to allow debugging in the global workspace (simulating an ongoing debug session)."
+                "description": "Whether to allow debugging in the global workspace after running the function/file."
               }
             }
           }
@@ -95,11 +90,10 @@
             "type": "R-Debugger",
             "request": "launch",
             "name": "R Debugger",
+            "debugMode": "file",
             "workingDirectory": "${workspaceFolder}",
             "program": "${file}",
             "mainFunction": "main",
-            "debugFunction": false,
-            "debugFile": false,
             "allowGlobalDebugging": true
           }
         ],
@@ -111,8 +105,7 @@
               "type": "R-Debugger",
               "request": "launch",
               "name": "R Debugger",
-              "debugFunction": false,
-              "debugFile": false,
+              "debugMode": "workspace",
               "allowGlobalDebugging": true
             }
           },
@@ -123,8 +116,7 @@
               "type": "R-Debugger",
               "request": "launch",
               "name": "R Debugger",
-              "debugFunction": false,
-              "debugFile": true,
+              "debugMode": "file",
               "program": "${file}",
               "allowGlobalDebugging": true
             }
@@ -136,9 +128,9 @@
               "type": "R-Debugger",
               "request": "launch",
               "name": "R Debugger",
-              "debugFunction": true,
-              "mainFunction": "main",
+              "debugMode": "function",
               "program": "${file}",
+              "mainFunction": "main",
               "allowGlobalDebugging": false
             }
           }

--- a/src/debugRuntime.ts
+++ b/src/debugRuntime.ts
@@ -24,14 +24,16 @@ export class DebugRuntime extends EventEmitter {
 	// need to occurr on the same line!
 	// need to match those used in the R-package
 	// TODO: replace with a dedicated pipe between R and vsc?
-	readonly rDelimiter0 = '<v\\s\\c>';
-	readonly rDelimiter1 = '</v\\s\\c>';
-	readonly rPrompt = '<#v\\s\\c>'; //actual prompt is followed by a newline to make easier to identify
-	readonly rContinue = '<##v\\s\\c>'; //actual prompt is followed by a newline to make easier to identify
-	readonly rStartup = '<v\\s\\c\\R\\STARTUP>';
-	readonly rLibraryNotFound = '<v\\s\\c\\LIBRARY\\NOT\\FOUND>';
-	readonly rPackageName = 'vscDebugger';
-	readonly rAppend = ' ### <v\\s\\c\\COMMAND>';
+	readonly rStrings = {
+		delimiter0: '<v\\s\\c>',
+		delimiter1: '</v\\s\\c>',
+		prompt: '<#v\\s\\c>', //actual prompt is followed by a newline to make easier to identify
+		continue: '<##v\\s\\c>', //actual prompt is followed by a newline to make easier to identify
+		startup: '<v\\s\\c\\R\\STARTUP>',
+		libraryNotFound: '<v\\s\\c\\LIBRARY\\NOT\\FOUND>',
+		packageName: 'vscDebugger',
+		append: ' ### <v\\s\\c\\COMMAND>'
+	};
 
 	// delay in ms between polls when waiting for messages from R
 	readonly pollingDelay = 10;
@@ -84,11 +86,10 @@ export class DebugRuntime extends EventEmitter {
 	private lastStackId = 0; // id of the last stack-message received from R
 
 	// debugMode
-	private callMain: boolean = false;
 	private mainFunction: string = 'main';
-	private callSource: boolean = false;
-	private allowDebugGlobal: boolean = false;
-	private debugMode: ('function'|'global') = 'function';
+	private allowGlobalDebugging: boolean = false;
+	private debugMode: "function"|"file"|"workspace";
+	private debugState: ('prep'|'function'|'global') = 'prep';
 	private setBreakpointsInPackages: boolean = false;
 
 
@@ -99,24 +100,18 @@ export class DebugRuntime extends EventEmitter {
 
 	// start
 	public async start(
-		debugFunction: boolean, debugFile: boolean,
+		debugMode: "function"|"file"|"workspace",
 		allowGlobalDebugging: boolean, workingDirectory: string,
 		program?: string, mainFunction?: string, includePackages: boolean = false
 	) {
 
 		// STORE LAUNCH CONFIG TO PROPERTIES
-		this.callMain = debugFunction;
-		this.callSource = debugFile;
-		this.allowDebugGlobal = allowGlobalDebugging;
+		this.debugMode = debugMode;
+		this.allowGlobalDebugging = allowGlobalDebugging;
 		this.cwd = workingDirectory;
 		this.sourceFile = program;
 		this.mainFunction = mainFunction;
 
-		if(this.callMain){
-			this.debugMode = 'function';
-		} else{
-			this.debugMode = 'global';
-		}
 
 		// LAUNCH R PROCESS
 
@@ -129,13 +124,13 @@ export class DebugRuntime extends EventEmitter {
 		// everything following this is printed in (collapsed) group
 		this.startOutputGroup('Starting R session...', true);
 		this.writeOutput(''
-			+ 'rDelimiter0: ' + this.rDelimiter0
-			+ '\nrDelimiter1: ' + this.rDelimiter1
-			+ '\nrPrompt: ' + this.rPrompt
-			+ '\nrContinue: ' + this.rContinue
-			+ '\nrStartup: ' + this.rStartup
-			+ '\nrLibraryNotFound: ' + this.rLibraryNotFound
-			+ '\nrAppend: ' + this.rAppend
+			+ 'rDelimiter0: ' + this.rStrings.delimiter0
+			+ '\nrDelimiter1: ' + this.rStrings.delimiter1
+			+ '\nrPrompt: ' + this.rStrings.prompt
+			+ '\nrContinue: ' + this.rStrings.continue
+			+ '\nrStartup: ' + this.rStrings.startup
+			+ '\nrLibraryNotFound: ' + this.rStrings.libraryNotFound
+			+ '\nrAppend: ' + this.rStrings.append
 		);
 
 		// start R in child process
@@ -163,10 +158,10 @@ export class DebugRuntime extends EventEmitter {
 		// CHECK IF R HAS STARTED
 
 		// cat message from R
-		this.rSession.callFunction('cat', this.rStartup, '\n', true, 'base');
+		this.rSession.callFunction('cat', this.rStrings.startup, '\n', true, 'base');
 
 		// set timeout
-		const ms = 1000;
+		const ms = 10000;
 		let timeout = new Promise((resolve, reject) => {
 			let id = setTimeout(() => {
 			clearTimeout(id);
@@ -190,17 +185,17 @@ export class DebugRuntime extends EventEmitter {
 
 		// load R package, wrapped in a try-catch-function
 		// missing R package will be handled by this.handleLine()
-		this.writeOutput('library: ' + this.rPackageName);
+		this.writeOutput('library: ' + this.rStrings.packageName);
 		const tryCatchArgs: anyRArgs = {
-			expr: makeFunctionCall('library', this.rPackageName, [], false, 'base'),
-			error: 'function(e)' + makeFunctionCall('cat', this.rLibraryNotFound, '\n', true, 'base'),
+			expr: makeFunctionCall('library', this.rStrings.packageName, [], false, 'base'),
+			error: 'function(e)' + makeFunctionCall('cat', this.rStrings.libraryNotFound, '\n', true, 'base'),
 			silent: true
 		};
 		this.rSession.callFunction('tryCatch', tryCatchArgs, [], false, 'base');
 
 		// all R function calls from here on are (by default) meant for functions from the vsc-extension:
-		this.rSession.defaultLibrary = this.rPackageName;
-		this.rSession.defaultAppend = this.rAppend;
+		this.rSession.defaultLibrary = this.rStrings.packageName;
+		this.rSession.defaultAppend = this.rStrings.append;
 
 
 		// PREP R SESSION AND SOURCE MAIN
@@ -216,37 +211,39 @@ export class DebugRuntime extends EventEmitter {
 			overwritePrint: overwritePrint,
 			overwriteCat: overwriteCat,
 			overwriteSource: overwriteSource,
-			findMain: this.callMain,
+			findMain: this.debugMode === 'function',
 			mainFunction:this.mainFunction,
-			debugGlobal: this.allowDebugGlobal
+			allowGlobalDebugging: this.allowGlobalDebugging,
+			rStrings: this.rStrings,
+			id: ++this.requestId
 		};
 		this.writeOutput(''
 			+ 'overwrite print(): ' + overwritePrint
 			+ '\noverwrite cat(): ' + overwriteCat
 			+ '\noverwrite source(): ' + overwriteSource
-			+ '\nallow global debugging: ' + this.allowDebugGlobal
+			+ '\nallow global debugging: ' + this.allowGlobalDebugging
 			+ '\nset breakpoints in packages: ' + this.setBreakpointsInPackages
+			+ '\ndebugMode: ' + this.debugMode
 		);
 		this.rSession.callFunction('.vsc.prepGlobalEnv', options);
 
-		if(this.callSource){
-			// debug-source the specified file
-			this.writeOutput(''
-				+ 'program: ' + program
-			);
-			// actual call to .vsc.debugSource is made after receiving a message 'go'
-		}
+		// await this.waitForMessages();
 
-		if(this.callMain){
+		if(this.debugMode === 'function'){
 			// source file that is being debugged
 			this.writeOutput(''
 				+ 'program: ' + program
 				+ '\nmain function: ' + this.mainFunction + '()'
 			);
-			this.rSession.callFunction('source', program, [], true, 'base');
-			this.rSession.callFunction('.vsc.lookForMain', this.mainFunction);
-			this.setAllBreakpoints();
+			// this.rSession.callFunction('source', program, [], true, 'base');
+			// this.rSession.callFunction('.vsc.lookForMain', this.mainFunction);
 			// actual call to main()/error if no main() found is made as response to message 'callMain'
+		} else if(this.debugMode === 'file'){
+			// debug-source the specified file
+			this.writeOutput(''
+				+ 'program: ' + program
+			);
+			// actual call to .vsc.debugSource is made after receiving a message 'go'
 		}
 
 
@@ -285,7 +282,7 @@ export class DebugRuntime extends EventEmitter {
 		var showLine = isFullLine && !this.stdoutIsBrowserInfo && this.isRunningCustomCode;
 
 		// filter out info meant for vsc:
-		const jsonRegex = new RegExp(escapeForRegex(this.rDelimiter0) + '(.*)' + escapeForRegex(this.rDelimiter1) + '$');
+		const jsonRegex = new RegExp(escapeForRegex(this.rStrings.delimiter0) + '(.*)' + escapeForRegex(this.rStrings.delimiter1) + '$');
 		const jsonMatch = jsonRegex.exec(line);
 		if(jsonMatch && isFullLine){
 			// is meant for the debugger, not the user
@@ -294,14 +291,15 @@ export class DebugRuntime extends EventEmitter {
 		}
 
 
+
 		// Check for R-Startup message
-		if(!this.isRunningCustomCode && RegExp(escapeForRegex(this.rStartup)).test(line)){
+		if(!this.isRunningCustomCode && RegExp(escapeForRegex(this.rStrings.startup)).test(line)){
 			this.hasStartedR = true;
 		}
 		// Check for Library-Not-Found-Message
-		if(!this.isRunningCustomCode && RegExp(escapeForRegex(this.rLibraryNotFound)).test(line)){
+		if(!this.isRunningCustomCode && RegExp(escapeForRegex(this.rStrings.libraryNotFound)).test(line)){
 			console.error('R-Library not found!');
-			vscode.window.showErrorMessage('Please install the R package "' + this.rPackageName + '"!');
+			vscode.window.showErrorMessage('Please install the R package "' + this.rStrings.packageName + '"!');
 			this.terminate();
 		}
 
@@ -348,7 +346,7 @@ export class DebugRuntime extends EventEmitter {
 		}
 
 		// matches echo of calls made by the debugger
-		const echoRegex = new RegExp(escapeForRegex(this.rAppend) + '$');
+		const echoRegex = new RegExp(escapeForRegex(this.rStrings.append) + '$');
 		if(isFullLine && echoRegex.test(line)){
 			// line = line.replace(echoRegex, '');
 			showLine = false;
@@ -357,27 +355,29 @@ export class DebugRuntime extends EventEmitter {
 
 
 		// check for prompt
-		const promptRegex = new RegExp(escapeForRegex(this.rPrompt));
+		const promptRegex = new RegExp(escapeForRegex(this.rStrings.prompt));
 		if(promptRegex.test(line) && isFullLine){
 			console.log("matches: prompt");
-			if(this.allowDebugGlobal){
-				if(this.debugMode === 'function'){
-					this.debugMode = 'global';
+			this.rSession.showsPrompt();
+			if(this.debugState === 'prep'){
+				// ignore
+			} else if(this.allowGlobalDebugging){
+				if(this.debugState === 'function'){
+					this.debugState = 'global';
 					await this.requestInfoFromR();
-					this.sendEvent('stopOnEntry');
+					this.sendEvent('stopOnStep');
 				}
 				this.endOutputGroup();
-				this.rSession.showsPrompt();
 				this.expectBrowser = false;
-			} else if(this.isRunningCustomCode){
-				// this.sendEvent('end');
+			} else{
+				this.sendEvent('end');
 			}
 			showLine = false;
 			return '';
 		}
 
 		// check for continue prompt
-		const continueRegex = new RegExp(escapeForRegex(this.rContinue));
+		const continueRegex = new RegExp(escapeForRegex(this.rStrings.continue));
 		if(continueRegex.test(line) && isFullLine){
 			console.log("matches: continue prompt");
 			showLine = false;
@@ -427,7 +427,7 @@ export class DebugRuntime extends EventEmitter {
 				this.stdoutIsBrowserInfo = true;
 				this.isCrashed = true;
 				this.expectBrowser = true;
-				this.debugMode = 'function';
+				this.debugState = 'function';
 				await this.requestInfoFromR();
 				// event is sent after receiving stack from R in order to answer stack-request synchronously:
 				// (apparently required by vsc?)
@@ -468,26 +468,41 @@ export class DebugRuntime extends EventEmitter {
 				// is sent by .vsc.prepGlobalEnv() to indicate that R is ready for .vsc.debugSource()
 				this.isRunningCustomCode = true;
 				this.rSession.useQueue = this.useRCommandQueue;
-				if(this.callSource){
+				if(this.debugMode === 'file'){
+					// call .vsc.debugSource()
 					this.debugSource(this.sourceFile);
-				} else if(this.debugMode === 'global'){
+				} else if(this.debugMode === 'function'){
+					// source file and look for main() function
+					this.rSession.callFunction('source', this.sourceFile, [], true, 'base');
+					this.rSession.callFunction('.vsc.lookForMain', this.mainFunction);
+					// actual call to main() is made after receiving 'callMain'
+				} else if(this.allowGlobalDebugging){
+					// simply start the R session and wait for user
+					this.debugState = 'global';
 					await this.requestInfoFromR();
 					this.sendEvent('stopOnEntry');
+				} else{
+					// Not a sensible usecase
+					this.terminate();
 				}
 				break;
 			case 'callMain':
 				// is sent by .vsc.prepGlobalEnv() to indicate that main() was found
 				this.rSession.useQueue = this.useRCommandQueue;
-				this.setAllBreakpoints();
+				this.setAllBreakpoints(true);
+				const beginMain = makeFunctionCall('.vsc.sendToVsc', {message: 'beginMain'});
 				const mainCall = makeFunctionCall(this.mainFunction,[],[],false,'');
-				const endCall = makeFunctionCall('.vsc.sendToVsc', {message: 'endMain'});
-				this.rSession.runCommand(mainCall + ';' + endCall);
+				const endMain = makeFunctionCall('.vsc.sendToVsc', {message: 'endMain'});
+				this.rSession.runCommand(beginMain + ';' + mainCall + ';' + endMain);
 				this.isRunningCustomCode = true;
+				break;
+			case 'beginMain':
+				this.debugState = 'function';
 				break;
 			case 'endMain':
 				// is sent after executing the main() function
-				if(!this.allowDebugGlobal){
-					this.debugMode = 'global';
+				if(!this.allowGlobalDebugging){
+					this.debugState = 'global';
 					this.terminate();
 				}
 				break;
@@ -553,7 +568,7 @@ export class DebugRuntime extends EventEmitter {
 
 	private async hitBreakpoint(expected: boolean = true){
 		this.expectBrowser = true; //indicates that following browser statements are no 'new' breakpoint
-		this.debugMode = 'function'; //browser is only called from inside a function/evaluated expression
+		this.debugState = 'function'; //browser is only called from inside a function/evaluated expression
 		if(expected){
 			// is sent BEFORE parsing all the browserInfo
 			this.stdoutIsBrowserInfo = true; 
@@ -643,8 +658,9 @@ export class DebugRuntime extends EventEmitter {
 	///////////////////////////////////////////////
 
 	// continue script execution:
-	public continue(reverse = false) {
-		if(this.debugMode === 'global'){
+	public async continue(reverse = false) {
+		if(this.debugState === 'global'){
+			await vscode.window.activeTextEditor.document.save();
 			const filename = vscode.window.activeTextEditor.document.fileName;
 			this.debugSource(filename);
 		} else{
@@ -681,7 +697,7 @@ export class DebugRuntime extends EventEmitter {
 
 	private async runCommandAndSendEvent(command: string, event: string = 'stopOnStep'){
 		if(this.isCrashed){
-			if(this.allowDebugGlobal){
+			if(this.allowGlobalDebugging){
 				this.returnToPrompt();
 			} else{
 				this.terminateFromPrompt();
@@ -760,7 +776,7 @@ export class DebugRuntime extends EventEmitter {
 			text: text,
 			column: column,
 			line: line,
-			onlyGlobalEnv: (this.debugMode === 'global'),
+			onlyGlobalEnv: (this.debugState === 'global'),
 			id: ++this.requestId
 		});
 		await this.waitForMessages();
@@ -797,7 +813,7 @@ export class DebugRuntime extends EventEmitter {
 		return bp;
 	}
 
-	private async setAllBreakpoints(){
+	private async setAllBreakpoints(setStoredBreakpoints: boolean = false){
 		// set breakpoints in R
 		// to be used after source()ing a R file and before calling the main() function from it
 		this.breakPoints.forEach((bps: DebugBreakpoint[], path:string) => {
@@ -811,7 +827,7 @@ export class DebugRuntime extends EventEmitter {
 			};
 			this.rSession.callFunction('.vsc.addBreakpoints', rArgs);
 		});
-		if(this.debugMode==='function'){
+		if(setStoredBreakpoints){
 			this.rSession.callFunction('.vsc.setStoredBreakpoints');
 		}
 
@@ -861,7 +877,7 @@ export class DebugRuntime extends EventEmitter {
 		this.rSession.ignoreOutput = true;
 		this.isRunningCustomCode = false;
 		this.rSession.clearQueue();
-		if(this.debugMode === 'function'){
+		if(this.debugState === 'function'){
 			this.rSession.runCommand('Q', [], true);
 			this.rSession.callFunction('quit', {save: 'no'}, [], true, 'base',true);
 			const infoString = "You terminated R while debugging a function.\n" +
@@ -876,10 +892,10 @@ export class DebugRuntime extends EventEmitter {
 
 	public async returnToPrompt() {
 		this.rSession.clearQueue();
-		if(this.debugMode === 'function'){
+		if(this.debugState === 'function'){
 			this.rSession.runCommand('Q', [], true);
 		}
-		this.debugMode = 'global';
+		this.debugState = 'global';
 		this.currentLine = 0;
 		const filename = vscode.window.activeTextEditor.document.fileName;
 		await this.requestInfoFromR({dummyFile: filename, forceDummyStack: true});

--- a/src/debugRuntime.ts
+++ b/src/debugRuntime.ts
@@ -350,7 +350,8 @@ export class DebugRuntime extends EventEmitter {
 		// matches echo of calls made by the debugger
 		const echoRegex = new RegExp(escapeForRegex(this.rAppend) + '$');
 		if(isFullLine && echoRegex.test(line)){
-			line = line.replace(echoRegex, '');
+			// line = line.replace(echoRegex, '');
+			showLine = false;
 			console.log('matches: echo');
 		}
 

--- a/src/debugSession.ts
+++ b/src/debugSession.ts
@@ -23,9 +23,8 @@ const { Subject } = require('await-notify');
 interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
 	/** An absolute path to the "program" to debug. */
 
-	program: string|undefined;
-	debugFunction: boolean;
-	debugFile: boolean;
+	file: string|undefined;
+	debugMode: ("function"|"file"|"workspace")
 	allowGlobalDebugging: boolean;
 	mainFunction: string|undefined;
 	workingDirectory: string;
@@ -224,14 +223,17 @@ export class DebugSession extends LoggingDebugSession {
 		// wait until configuration has finished (and configurationDoneRequest has been called)
 		await this._configurationDone.wait(1000);
 
+		const debugFunction = args.debugMode === 'function';
+		const debugFile = args.debugMode === 'file';
+
+
 		// start the program in the runtime
 		// this._runtime.start(args.program, args.allowGlobalDebugging, args.debugFunction, args.mainFunction);
 		this._runtime.start(
-			args.debugFunction,
-			args.debugFile,
+			args.debugMode,
 			args.allowGlobalDebugging,
 			args.workingDirectory,
-			args.program,
+			args.file,
 			args.mainFunction
 		);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,28 +45,29 @@ class DebugConfigurationProvider implements vscode.DebugConfigurationProvider {
 				config.type = 'R-Debugger';
 				config.name = 'Launch';
 				config.request = 'launch';
-				config.debugFunction = false;
-				config.allowGlobalDebugging = true;
+				config.debugMode = 'workspace';
 				config.workingDirectory = "${workspaceRoot}";
 			}
-		} else if(config.debugFunction){
-			if(!config.program || !config.mainFunction){
-				return vscode.window.showErrorMessage("Please specify an R file as 'program' and a function name in the Debugger config.").then(_ => {
+		} else if(config.debugMode === 'function'){
+			if(!config.file || !config.mainFunction){
+				return vscode.window.showErrorMessage("Please specify an R file as 'file' and a function name in the Debugger config.").then(_ => {
 					return undefined;
 				});
 			} else if(!config.workingDirectory){
-				config.workingDirectory = "${fileDirname}";
+				config.workingDirectory = "${workspaceFolder}";
 			}
-		} else if(config.debugFile){
-			if(!config.program){
-				return vscode.window.showErrorMessage("Please specify an R file as 'program'.").then(_ => {
+		} else if(config.debugMode === 'file'){
+			if(!config.file){
+				return vscode.window.showErrorMessage("Please specify an R file as 'file'.").then(_ => {
 					return undefined;
 				});
 			} else if(!config.workingDirectory){
-				config.workingDirectory = "${fileDirname}";
+				config.workingDirectory = "${workspaceFolder}";
 			}
-		} else if(!config.workingDirectory){
-			config.workingDirectory = "${workspaceFolder}";
+		} else { // config.debugMode === 'workspace'
+			if(!config.workingDirectory){
+				config.workingDirectory = "${workspaceFolder}";
+			}
 		}
 		return config;
 	}

--- a/src/rSession.ts
+++ b/src/rSession.ts
@@ -69,7 +69,7 @@ export class RSession {
         this.successTerminal = true;
     }
 
-    public async runCommand(cmd: string, args: (string|number)[]=[], force=false, append?: string){
+    public async runCommand(cmd: string, args: (string|number)[]=[], force=false, append: string = ''){
         // remove trailing newline
 		while(cmd.length>0 && cmd.slice(-1) === '\n'){
             cmd = cmd.slice(0, -1);
@@ -115,7 +115,7 @@ export class RSession {
             this.isBusy = true;
             const cmd = this.cmdQueue.shift();
             console.log('rSession: calling from list: "' + cmd.trim() + '"');
-            this.runCommand(cmd, [], true);
+            this.runCommand(cmd, [], true, '');
         } else{
             this.isBusy = false;
         }
@@ -216,9 +216,11 @@ function convertArgsToStrings(args:anyRArgs=[], escapeStrings:boolean = false): 
         args = args.map((arg) => convertArgsToStrings(arg, escapeStrings));
     } else if(args!==null && typeof args === 'object'){
         //namedRArgs
+        const ret = {};
         for(const arg in <namedRArgs>args){
-            args[arg] = convertArgsToStrings(args[arg], escapeStrings);
+            ret[arg] = convertArgsToStrings(args[arg], escapeStrings);
         }
+        args = ret;
     } else if(args === undefined){
         //undefined
         args = 'NULL';
@@ -282,7 +284,9 @@ function convertToUnnamedArg(arg: unnamedRArg|rList): unnamedRArg{
     var ret: unnamedRArg;
     if(Array.isArray(arg)){
         // is rList
-        ret = makeFunctionCall('list', arg, [], false,'base');
+        ret = makeFunctionCall('list', arg, [], false,'base', '');
+    } else if(arg!==null && typeof arg === 'object'){
+        ret = makeFunctionCall('list', arg, [], false, 'base', '');
     } else{
         ret = <unnamedRArg>arg;
     }

--- a/src/rSession.ts
+++ b/src/rSession.ts
@@ -69,17 +69,22 @@ export class RSession {
         this.successTerminal = true;
     }
 
-    public async runCommand(cmd: string, args: (string|number)[]=[], force=false){
+    public async runCommand(cmd: string, args: (string|number)[]=[], force=false, append?: string){
         // remove trailing newline
 		while(cmd.length>0 && cmd.slice(-1) === '\n'){
             cmd = cmd.slice(0, -1);
         }
 
+
+        if(append === undefined){
+            append = this.defaultAppend;
+        }
+
         // append arguments (if any given) and newline
         if(args.length > 0){
-            cmd = cmd + ' ' + args.join(' ') + '\n';
+            cmd = cmd + ' ' + args.join(' ') + append + '\n';
         } else {
-            cmd = cmd + '\n';
+            cmd = cmd + append + '\n';
         }
 
         // execute command or add to command queue
@@ -123,8 +128,8 @@ export class RSession {
         force:boolean=false, append: string = this.defaultAppend
     ){
         // two sets of arguments (args and args2) to allow mixing named and unnamed arguments
-        const cmd = makeFunctionCall(fnc, args, args2, escapeStrings, library, append);
-        this.runCommand(cmd, [], force);
+        const cmd = makeFunctionCall(fnc, args, args2, escapeStrings, library);
+        this.runCommand(cmd, [], force, append);
     }
 
     // Kill the child process

--- a/src/rSession.ts
+++ b/src/rSession.ts
@@ -21,7 +21,7 @@ export class RSession {
     public useQueue: boolean = false;
     public cmdQueue: string[] = [];
     public logLevel: number = 3;
-    public readonly logLevelCP: number = 3; // can only be changed during construction
+    public readonly logLevelCP: number = 4; // can only be changed during construction
     public waitBetweenCommands: number = 0;
     public defaultLibrary: string = '';
     public defaultAppend: string = '';

--- a/test/R/.vscode/launch.json
+++ b/test/R/.vscode/launch.json
@@ -8,28 +8,27 @@
             "type": "R-Debugger",
             "request": "launch",
             "name": "R Debug File",
-            "program": "${file}",
-            "debugFunction": false,
-            "debugFile": true,
+            "workingDirectory": "${fileDirname}",
+            "file": "${file}",
+            "debugMode": "file",
             "allowGlobalDebugging": true
         },
         {
             "type": "R-Debugger",
             "request": "launch",
             "name": "R Debug Only Workspace",
+            "debugMode": "workspace",
             "workingDirectory": "${workspaceFolder}",
-            "debugFunction": false,
-            "debugFile": false,
             "allowGlobalDebugging": true
         },
         {
             "type": "R-Debugger",
             "request": "launch",
             "name": "R Debug Function",
-            "program": "${file}",
+            "debugMode": "function",
+            "workingDirectory": "${fileDirname}",
+            "file": "${file}",
             "mainFunction": "main",
-            "debugFunction": true,
-            "debugFile": false,
             "allowGlobalDebugging": false
         }
     ]

--- a/test/R/test.R
+++ b/test/R/test.R
@@ -11,6 +11,10 @@ foo <- function(x,y){
   print(x)
   print("A breakpoint here should work with debugMode==function")
   print("A breakpoint here should also work from the debug console, if .vsc.debugSource() or debugMode==file was used")
+  # Currently, breakpoints are only set during runtime, when .vsc.debugSource() is called
+  # Also, breakpoints are 'permanent' and can only be deactivated by calling .vsc.debugSource() again
+  # In the future this should be refined by using trace(..., tracer=browser), to facilitate better breakpoint setting/clearing
+
   print(y)
   return(x+y)
 }

--- a/test/R/test.R
+++ b/test/R/test.R
@@ -9,8 +9,8 @@ print("A breakpoint here should NOT work with debugMode==function")
 
 foo <- function(x,y){
   print(x)
-  print("A breakpoint here should work with debugMode==function or debugMode==file")
-  print("A breakpoint here should also work from the debug console, if .vsc.debugSource() was used")
+  print("A breakpoint here should work with debugMode==function")
+  print("A breakpoint here should also work from the debug console, if .vsc.debugSource() or debugMode==file was used")
   print(y)
   return(x+y)
 }

--- a/test/R/test.R
+++ b/test/R/test.R
@@ -1,43 +1,24 @@
-foo <- function(x, y) {
+
+
+
+print("This will be printed with debugMode==file or debugMode==function")
+print("A breakpoint here should work with debugMode==file or from .vsc.debugSource()")
+print("A breakpoint here should NOT work with debugMode==function")
+
+
+
+foo <- function(x,y){
   print(x)
-  print(y); print(0)
-  l <- list(1,2,3)
-  lng <- length(l)
-  x + y
-  return(100)
-} 
-
-bar <- function(x, n) {
-  z <- x
-  for (i in seq_len(n)) {
-    print(i)
-    z <- foo(z, x)
-  }
-  z
-}
-
-
-f1 <- 100
-fara <- 123
-fuck <- 0
-fantom <- FALSE
-phantom <- TRUE
-l <- list(a=1, b=2, c=3)
-
-g <- function(){
-  # asd
-  print('g')
-  return(list(1,2,333))
+  print("A breakpoint here should work with debugMode==function or debugMode==file")
+  print("A breakpoint here should also work from the debug console, if .vsc.debugSource() was used")
+  print(y)
+  return(x+y)
 }
 
 main <- function(){
-  g()
+  print(1)
+  print("This should only be printed if debugMode==function or main() was entered into the debug console")
+  foo(2,3)
 }
 
-# g()
-
-base::cat('asdf')
-
-
-base::cat('qwer\n')
 


### PR DESCRIPTION
Fixes #37 

This pr includes bug fixes and significant changes to the debug config and handling of the debug mode inside the debugRuntime.

The debug config entries `callMain: boolean` and `callSource: boolean` are replaced by `debugMode: ("function"|"file"|"workspace")`. The intended usecases for these modes are:

* `"workspace"`: Starts an R process in the background and sends all input into the debug console to the R process (but indirectly, through `eval()` nested in some helper functions). R Files can be run by focussing a file and pressing `F5`. The stack view contains a single dummy frame. To view the variables in the global environment it is often necessary to click this frame and expand the variables view. This method is 'abusing' the DAP to some extent, since the protocol is apparently not designed for ongoing interactive programming in a global workspace.
* `"file"`: Is pretty much equivalent to launching the debugger with `"workspace"` and then calling `.vsc.debugSource()` on a file. Is hopefully the behaviour expected by users coming from R Studio etc.
* `"function"`: The above debug modes introduce significant overhead by passing all input through `eval()` etc. and use a custom version of `source()`, which makes changes to the R code in order to set breakpoints. To provide a somewhat 'cleaner' method of running code, this debug mode can be used used. The call to `main()` is entered directly into R's `stdin`, hence there are no additional functions on the call stack (as is the case when entering `main()` into the debug console). Breakpoints are set by using R's `trace(..., tracer=browser)` function.
