### PR TITLE
Moved error messages to debug console

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ The debugger includes the following features:
 * Information about the stack trace, scopes, variables, and watch expressions in each frame/scope
 * Exception handling (breaks on exception, access to stack info)
 * Evaluation of arbitrary R code in the selected stack frame
-* Overwriting `print()` and `cat()` with modified versions that also print the current source file and line the the debug console
+* Overwriting `print()` and `cat()` with modified versions that also print the calling source file and line to the debug console
 * Overwriting `source()` with `.vsc.debugSource()` to allow recursive debugging (i.e. breakpoints in files that are `source()`d from within another file)
 * Supports VS Code's remote development extensions
 
@@ -73,7 +73,7 @@ This method is 'abusing' the debug adapter protocol to some extent, since the pr
 Is hopefully the behaviour expected by users coming from R Studio etc.
 * `"function"`: The above debug modes introduce significant overhead by passing all input through `eval()` etc.
 and use a custom version of `source()`, which makes changes to the R code in order to set breakpoints.
-To provide a somewhat 'cleaner' method of running code, this debug mode can be used used.
+To provide a somewhat 'cleaner' method of running code, this debug mode can be used.
 The call to `main()` is entered directly into R's `stdin`, hence there are no additional functions on the call stack (as is the case when entering `main()` into the debug console).
 Breakpoints are set by using R's `trace(..., tracer=browser)` function, which is more robust than the custom breakpoint mechanism.
 

--- a/src/debugSession.ts
+++ b/src/debugSession.ts
@@ -450,11 +450,13 @@ export class DebugSession extends LoggingDebugSession {
 
     protected dispatchRequest(request: DebugProtocol.Request): void {
 		console.log('request ' + request.seq + ': ' + request.command);
+		console.log(request);
 		super.dispatchRequest(request);
 	}
 
     sendResponse(response: DebugProtocol.Response): void {
 		console.log('response ' + response.request_seq + ': ' + response.command);
+		console.log(response);
 		super.sendResponse(response);
 	}
 

--- a/src/rSession.ts
+++ b/src/rSession.ts
@@ -21,7 +21,7 @@ export class RSession {
     public useQueue: boolean = false;
     public cmdQueue: string[] = [];
     public logLevel: number = 3;
-    public readonly logLevelCP: number = 4; // can only be changed during construction
+    public readonly logLevelCP: number = 3; // can only be changed during construction
     public waitBetweenCommands: number = 0;
     public defaultLibrary: string = '';
     public defaultAppend: string = '';


### PR DESCRIPTION
Show error messages in the debug console rather than using `vscode.window.showErrorMessage`.
Some minor changes to readme, R startup timeout, and logging