### PR TITLE
Add support to copy variables to clipboard

### DIFF
--- a/src/debugSession.ts
+++ b/src/debugSession.ts
@@ -425,8 +425,13 @@ export class DebugSession extends LoggingDebugSession {
 	}
 
 	protected evaluateRequest(response: DebugProtocol.EvaluateResponse, args: DebugProtocol.EvaluateArguments): void {
-		const requestIdR = this._runtime.evaluate(args.expression, args.frameId, args.context);
-		this._evalResponses.set(requestIdR, response);
+		if(args.context === 'clipboard'){
+			response.success = false;
+			this.sendResponse(response);
+		} else{
+			const requestIdR = this._runtime.evaluate(args.expression, args.frameId, args.context);
+			this._evalResponses.set(requestIdR, response);
+		}
 	}
 
 


### PR DESCRIPTION
Adds support to copy variables to clipboard.
Rightclick -> 'Copy Value' copies the string representation
Rightclick -> 'Copy as Expression' copies the deparsed value of the variable

`evaluateRequests` with context `"clipboard"` are answered with `success = false`, which causes vscode to use the (previously provided) string representation.

Relies on https://github.com/ManuelHentschel/vscDebugger/pull/52