### PR TITLE
Add example customAttributes entry

### DIFF
--- a/test/R/objects.R
+++ b/test/R/objects.R
@@ -101,3 +101,13 @@ main <- function() {
   fun(1, a = 1, b = 2)
   browser()
 }
+
+.vsc.addVarInfo(
+  name = 'Bytes',
+  doesApply = function(v) TRUE, # could be narrowed down
+  customAttributes = function(v) list(
+    names=list('__bytes'),
+    values=list(unclass(object.size(v)))
+  ),
+  position = -2 # append just before the default case
+)


### PR DESCRIPTION
Adds an example to test custom varInfos.
Shows effects of e.g. https://github.com/ManuelHentschel/vscDebugger/pull/54
