### PR TITLE
Added/Modified several config entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,11 +89,10 @@
           {
             "type": "R-Debugger",
             "request": "launch",
-            "name": "R Debugger",
+            "name": "R Debug File",
+            "workingDirectory": "${fileDirname}",
+            "file": "${file}",
             "debugMode": "file",
-            "workingDirectory": "${workspaceFolder}",
-            "program": "${file}",
-            "mainFunction": "main",
             "allowGlobalDebugging": true
           }
         ],
@@ -104,8 +103,9 @@
             "body": {
               "type": "R-Debugger",
               "request": "launch",
-              "name": "R Debugger",
+              "name": "R Debug Only Workspace",
               "debugMode": "workspace",
+              "workingDirectory": "${workspaceFolder}",
               "allowGlobalDebugging": true
             }
           },
@@ -115,9 +115,9 @@
             "body": {
               "type": "R-Debugger",
               "request": "launch",
-              "name": "R Debugger",
-              "debugMode": "file",
-              "program": "${file}",
+              "name": "R Debug Only Workspace",
+              "debugMode": "workspace",
+              "workingDirectory": "${workspaceFolder}",
               "allowGlobalDebugging": true
             }
           },
@@ -127,9 +127,10 @@
             "body": {
               "type": "R-Debugger",
               "request": "launch",
-              "name": "R Debugger",
+              "name": "R Debug Function",
               "debugMode": "function",
-              "program": "${file}",
+              "workingDirectory": "${fileDirname}",
+              "file": "${file}",
               "mainFunction": "main",
               "allowGlobalDebugging": false
             }
@@ -190,6 +191,16 @@
           "type": "boolean",
           "default": false,
           "description": "Set to true to show package scopes in the variable window."
+        },
+        "rdebugger.startupTimeout": {
+          "type": "number",
+          "default": 2000,
+          "description": "The maximum time in ms that is waited for R to startup"
+        },
+        "rdebugger.printEverything": {
+          "type": "boolean",
+          "default": false,
+          "description": "For debugging the debugger: Whether to show everything printed to stdoutor stderr by the child process. Recommended to set debug.console.wordWrap=false"
         }
       }
     }

--- a/src/debugRuntime.ts
+++ b/src/debugRuntime.ts
@@ -180,7 +180,7 @@ export class DebugRuntime extends EventEmitter {
 		// abort if the terminal does not print the message (--> R has not started!)
 		if(!successR){
 			this.endOutputGroup();
-			this.writeOutput('R not responding within ' + this.startupTimeout + 'ms!', true, true)
+			this.writeOutput('R not responding within ' + this.startupTimeout + 'ms!', true, true);
 			this.writeOutput('R path:\n' + rPath, true, true);
             // vscode.window.showErrorMessage('R path not working:\n' + rPath);
 			this.terminate();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,8 +45,10 @@ class DebugConfigurationProvider implements vscode.DebugConfigurationProvider {
 				config.type = 'R-Debugger';
 				config.name = 'Launch';
 				config.request = 'launch';
-				config.debugMode = 'workspace';
-				config.workingDirectory = "${workspaceRoot}";
+				config.debugMode = 'file';
+				config.file = '${file}';
+				config.workingDirectory = "${fileDirname}";
+				config.allowGlobalDebugging = true;
 			}
 		} else if(config.debugMode === 'function'){
 			if(!config.file || !config.mainFunction){


### PR DESCRIPTION
Fixes some of the issues mentioned in https://github.com/ManuelHentschel/VSCode-R-Debugger/issues/6:

- Fixes the default launch config for the debugger
- Adds an option to set the startup timeout for R
- Prints the startup timeout if R is not found
- Adds an option to print everything from the child process to the debug console

