### PR TITLE
Enable direct input into stdin

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -104,9 +104,8 @@ Output parsing relies on parsing complete lines, so any output produced by `cat(
 Using the option to overwrite `cat()` will show output immediately, but produce a linebreak after each `cat()` call.
 * Output to stdout that looks like output from `browser()`, the input prompt, or text meant for the debugger (e.g. `<v\s\c>...</v\s\c>`)
 * Code that contains calls to `sys.calls()`, `sys.frames()`, `attr(..., 'srcref')` etc.:
-Since most code is evaluated through calls to `eval(...)` these results might be wrong.
-This problem might be reduced by using the "functional" debug mode
-(set `debugFunction` to `true` and specify a `mainFunction` in the launch config)
+Since pretty much all code is evaluated through calls to `eval(...)` these results might be wrong. <!-- This problem might be reduced by using the "functional" debug mode --> <!-- (set `debugFunction` to `true` and specify a `mainFunction` in the launch config) -->
+If required, input in the debug console can be sent directly to R's `stdin` by prepending it with `###stdin`.
 * Any use of graphical output/input, stdio-redirecting, `sink()`
 * Extensive use of lazy evaluation, promises, side-effects:
 In the general case, the debugger recognizes unevaluated promises and preserves them.

--- a/src/debugRuntime.ts
+++ b/src/debugRuntime.ts
@@ -65,7 +65,7 @@ export class DebugRuntime extends EventEmitter {
 	private logLevel = 3;
 
 	// The rSession used to run the code
-	private rSession: RSession;
+	public rSession: RSession;
 	// Whether to use a queue for R commands (makes debugging slower but 'safer')
 	private useRCommandQueue: boolean = true;
 	// Time in ms to wait before sending an R command (makes debugging slower but 'safer')
@@ -329,6 +329,7 @@ export class DebugRuntime extends EventEmitter {
 		const continueRegex = new RegExp(escapeForRegex(this.rStrings.continue));
 		if(continueRegex.test(line) && isFullLine){
 			console.log("matches: continue prompt");
+			this.writeOutput("...");
 			showLine = false;
 		}
 

--- a/src/debugSession.ts
+++ b/src/debugSession.ts
@@ -113,6 +113,19 @@ export class DebugSession extends ProtocolServer {
                     dispatchToR = true;
                     sendResponse = false;
                     break;
+                case 'evaluate':
+                    const matches = /^### ?[sS][tT][dD][iI][nN]\s*(.*)/.exec(request.arguments.expression);
+                    if(matches){
+                        const toStdin = matches[1];
+                        console.log('cp.stdin:\n' + toStdin);
+                        this._runtime.rSession.cp.stdin.write(
+                            toStdin + '\n'
+                        );
+                    } else{
+                        dispatchToR = true;
+                        sendResponse = false;
+                    }
+                    break;
                 case 'disconnect':
                     this._runtime.terminateFromPrompt();
                     break;


### PR DESCRIPTION
Makes it possible to to write directly to stdin of the R process by prepending the text entered in the debug console with "###stdin". This can be useful, when debugging the debugger itself, when direct access to e.g. the call stack is desired or the script that is executed contains user prompts.

This will usually mess with the debugger's ability to keep track of the current line in a source file and circumvent the debugger's error handling.

Examples:
```
> ###stdin
  sys.nframe()

  [1] 0

> sys.nframe()

  10L
```

```
> 1 + (2 *

  Error in parse(text = expr) : <text>:2:0: unexpected end of input
  1: 1 + (2 *
     ^

> ###stdin
  1 + (2 *

  ...

> ###stdin
  3)

  [1] 7
```