### PR TITLE
Use port

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1289,6 +1289,11 @@
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
 		},
+		"net": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/net/-/net-1.0.2.tgz",
+			"integrity": "sha1-0XV+yaf7I3HYPPR1XOPifhCCk4g="
+		},
 		"nice-try": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -232,6 +232,7 @@
   },
   "dependencies": {
     "await-notify": "^1.0.1",
+    "net": "^1.0.2",
     "vscode-debugadapter": "^1.40.0",
     "winreg": "^1.2.4"
   }

--- a/src/debugProtocolModifications.ts
+++ b/src/debugProtocolModifications.ts
@@ -63,6 +63,9 @@ export interface RStrings {
 export interface InitializeRequestArguments extends DebugProtocol.InitializeRequestArguments {
     rStrings?: RStrings;
     threadId?: number;
+    host?: string;
+    port?: number;
+    useServer?: boolean;
 }
 
 export interface InitializeRequest extends DebugProtocol.InitializeRequest {

--- a/src/debugProtocolModifications.ts
+++ b/src/debugProtocolModifications.ts
@@ -9,6 +9,16 @@ export enum DebugMode {
     Workspace = "workspace"
 }
 
+
+
+export interface RStartupArguments {
+    path: string;
+    args: string[];
+    logLevel?: number;
+    logLevelCP?: number;
+}
+
+
 export interface DebugConfiguration extends VsCode.DebugConfiguration {
     // specify what to debug (required)
     debugMode: DebugMode;

--- a/src/debugRuntime.ts
+++ b/src/debugRuntime.ts
@@ -389,11 +389,24 @@ export class DebugRuntime extends EventEmitter {
 
 	// receive requests from the debugSession
 	public dispatchRequest(request: DebugProtocol.Request) {
-		// this.rSession.callFunction('.vsc.dispatchRequest', <anyRArgs><unknown>request);
 		const json = JSON.stringify(request);
 		this.rSession.callFunction('.vsc.handleJson', {json: json});
-		// this.rSession.callFunction('.vsc.dispatchRequest', {request: request});
 	}
+
+	// // This version dispatches requests to the tcp connection instead of stdin
+	// // Is not yet working properly. Current problems/todos:
+	// //  - Some requests not handled by R (step, stepIn, stepOut, ...)
+	// //  - .vsc.listenOnPort needs to be called everytime the prompt is shown
+	// //    Is possible using addTaskCallback, but this does not work e.g. when stepping through code
+	//
+	// public dispatchRequest(request: DebugProtocol.Request, usePort: boolean = false) {
+	// 	if(this.jsonServer.socket && usePort){
+	// 		this.jsonServer.socket.write(json + '\n');
+	// 	} else{
+	// 		this.rSession.callFunction('.vsc.handleJson', {json: json});
+	// 		this.rSession.callFunction('.vsc.listenOnPort', {timeout: 3});
+	// 	}
+	// }
 
 	// send event to the debugSession
 	private sendEvent(event: string, ... args: any[]) {

--- a/src/debugSession.ts
+++ b/src/debugSession.ts
@@ -8,6 +8,10 @@ import { basename } from 'path';
 import { DebugRuntime } from './debugRuntime';
 const { Subject } = require('await-notify');
 
+const { net } = require("net");
+
+
+
 
 import { Response } from 'vscode-debugadapter/lib/messages';
 import { ProtocolServer } from 'vscode-debugadapter/lib/protocol';
@@ -20,8 +24,8 @@ export class DebugSession extends ProtocolServer {
 	private THREAD_ID = 1;
 
 	// a runtime (or debugger)
-	private _runtime: DebugRuntime;
-
+    private _runtime: DebugRuntime;
+    
 
     sendResponse(response: DebugProtocol.Response): void {
         console.log("reponse " + response.request_seq + ": " + response.command, response);

--- a/src/debugSession.ts
+++ b/src/debugSession.ts
@@ -17,6 +17,7 @@ import { Response } from 'vscode-debugadapter/lib/messages';
 import { ProtocolServer } from 'vscode-debugadapter/lib/protocol';
 import { DebugProtocol } from 'vscode-debugprotocol';
 import { SourceArguments, InitializeRequest, ContinueArguments, StrictDebugConfiguration, ResponseWithBody, InitializeRequestArguments } from './debugProtocolModifications';
+import { config } from './utils';
 
 export class DebugSession extends ProtocolServer {
 
@@ -28,7 +29,7 @@ export class DebugSession extends ProtocolServer {
 
 
     sendResponse(response: DebugProtocol.Response): void {
-        console.log("reponse " + response.request_seq + ": " + response.command, response);
+        console.log("response " + response.request_seq + ": " + response.command, response);
 		super.sendResponse(response);
     }
     
@@ -101,7 +102,7 @@ export class DebugSession extends ProtocolServer {
             switch(request.command){
                 case 'initialize':
                     const initializeArguments: InitializeRequestArguments = request.arguments || {};
-                    initializeArguments.useServer = true;
+                    initializeArguments.useServer = config().get<boolean>('useServer', true);
                     initializeArguments.threadId = this.THREAD_ID;
                     const initializeRequest: InitializeRequest = {
                         arguments: initializeArguments,

--- a/src/rSession.ts
+++ b/src/rSession.ts
@@ -3,6 +3,7 @@
 import * as child from 'child_process';
 import { TextDecoder } from 'util';
 import { DebugRuntime } from'./debugRuntime';
+import { RStartupArguments } from './debugProtocolModifications';
 
 function timeout(ms: number) {
 	return new Promise(resolve => setTimeout(resolve, ms));
@@ -13,6 +14,17 @@ export type unnamedRArgs = (unnamedRArg|rList)[];
 export type namedRArgs = {[arg:string]: unnamedRArg|rList};
 export type rList = (unnamedRArgs|namedRArgs);
 export type anyRArgs = (unnamedRArg|unnamedRArgs|namedRArgs);
+
+// this is only typed to avoid typos in the function names
+export type RFunctionName = (
+    ".vsc.dispatchRequest" |
+    "cat" |
+    "print" |
+    ".vsc.handleJson" |
+    "tryCatch" |
+    ".vsc.debugSource" |
+    "quit"
+);
 
 
 export class RSession {
@@ -32,21 +44,18 @@ export class RSession {
     private restOfStdout: string='';
 
 
-    constructor(rPath: string, rArgs: string[]=[],
-        // handleLine: (line:string,fromStderr:boolean,isFullLine:boolean)=>(Promise<string>),
-        debugRuntime: DebugRuntime,
-        logLevel=undefined, logLevelCP=undefined)
+    // constructor(rPath: string, rArgs: string[]=[],
+    //     // handleLine: (line:string,fromStderr:boolean,isFullLine:boolean)=>(Promise<string>),
+    //     debugRuntime: DebugRuntime,
+    //     logLevel=undefined, logLevelCP=undefined)
+    constructor(args: RStartupArguments, debugRuntime: DebugRuntime)
     {
         // spawn new terminal process (necessary for interactive R session)
 
-        if(!logLevel === undefined){
-            this.logLevel = logLevel;
-        }
-        if(!logLevelCP === undefined){
-            this.logLevelCP = logLevelCP;
-        }
+        this.logLevel = args.logLevel || this.logLevel;
+        this.logLevelCP = args.logLevelCP || this.logLevelCP;
 
-        this.cp = spawnRProcess(rPath, rArgs, this.logLevelCP);
+        this.cp = spawnRProcess(args);
 
         if(this.cp.pid === undefined){
             this.successTerminal = false;
@@ -123,7 +132,7 @@ export class RSession {
 
 
     // Call an R-function (constructs and calls the command)
-    public callFunction(fnc: string, args: any|anyRArgs=[], args2: anyRArgs=[],
+    public callFunction(fnc: RFunctionName, args: any|anyRArgs=[], args2: anyRArgs=[],
         escapeStrings: boolean=true, library: string = this.defaultLibrary,
         force:boolean=false, append: string = this.defaultAppend
     ){
@@ -303,7 +312,7 @@ function convertToUnnamedArg(arg: unnamedRArg|rList): unnamedRArg{
 /////////////////////////////////
 // Child Process
 
-function spawnRProcess(rPath: string, rArgs: string[] = [], logLevel=3){
+function spawnRProcess(args: RStartupArguments){
     const options = {
         env: {
             VSCODE_DEBUG_SESSION: "1",
@@ -312,8 +321,12 @@ function spawnRProcess(rPath: string, rArgs: string[] = [], logLevel=3){
         shell: true
     };
 
+    const rPath = args.path;
+    const rArgs = args.args;
+
     const cp = child.spawn(rPath, rArgs, options);
 
+    const logLevel = args.logLevelCP || 0;
     // log output to console.log:
     if(logLevel>=4){
         cp.stdout.on("data", data => {

--- a/src/rSession.ts
+++ b/src/rSession.ts
@@ -32,7 +32,7 @@ export class RSession {
     private restOfStdout: string='';
 
 
-    constructor(rPath: string, cwd: string, rArgs: string[]=[],
+    constructor(rPath: string, rArgs: string[]=[],
         // handleLine: (line:string,fromStderr:boolean,isFullLine:boolean)=>(Promise<string>),
         debugRuntime: DebugRuntime,
         logLevel=undefined, logLevelCP=undefined)
@@ -46,7 +46,7 @@ export class RSession {
             this.logLevelCP = logLevelCP;
         }
 
-        this.cp = spawnRProcess(rPath, cwd, rArgs, this.logLevelCP);
+        this.cp = spawnRProcess(rPath, rArgs, this.logLevelCP);
 
         if(this.cp.pid === undefined){
             this.successTerminal = false;
@@ -303,9 +303,8 @@ function convertToUnnamedArg(arg: unnamedRArg|rList): unnamedRArg{
 /////////////////////////////////
 // Child Process
 
-function spawnRProcess(rPath: string, cwd: string, rArgs: string[] = [], logLevel=3){
+function spawnRProcess(rPath: string, rArgs: string[] = [], logLevel=3){
     const options = {
-        cwd: cwd,
         env: {
             VSCODE_DEBUG_SESSION: "1",
             ...process.env

--- a/src/rSession.ts
+++ b/src/rSession.ts
@@ -34,7 +34,7 @@ export class RSession {
     public useQueue: boolean = false;
     public cmdQueue: string[] = [];
     public logLevel: number = 3;
-    public readonly logLevelCP: number = 4;
+    public readonly logLevelCP: number = 3;
     public waitBetweenCommands: number = 0;
     public defaultLibrary: string = '';
     public defaultAppend: string = '';

--- a/src/rSession.ts
+++ b/src/rSession.ts
@@ -23,7 +23,8 @@ export type RFunctionName = (
     ".vsc.handleJson" |
     "tryCatch" |
     ".vsc.debugSource" |
-    "quit"
+    "quit" |
+    ".vsc.listenOnPort"
 );
 
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,76 @@
+
+// const net = require('net');
+import * as net from 'net';
+
+import { TextDecoder } from 'util';
+
+const { Subject } = require('await-notify');
+
+
+import { DebugRuntime } from'./debugRuntime';
+
+
+export class JsonServer {
+
+    constructor() {}
+
+    public host: string;
+    public port: number;
+    public server: net.Server;
+    public restOfLine: string = "";
+    public debugRuntime: DebugRuntime;
+    
+    async makeServer(debugRuntime: DebugRuntime, host: string = '127.0.0.1', port: number = 0) {
+        this.debugRuntime = debugRuntime;
+        this.host = host;
+        this.port = port;
+        const _this = this;
+        this.server = net.createServer((sock) => {
+            // Add a 'data' event handler to this instance of socket
+            sock.on('data', (data) => {
+                // post data to a server so it can be saved and stuff
+                this.handleData(data);
+            });
+
+
+        });
+        const serverReady = new Subject();
+        this.server.listen(0, this.host, function () {
+            serverReady.notify();
+        });
+
+        await serverReady.wait(1000);
+
+        const address = this.server.address();
+        if (typeof address === 'string' || address === undefined) {
+            this.port = 0;
+        } else {
+            this.port = address.port;
+        }
+    }
+
+    handleData = (data: Buffer) => {
+		const dec = new TextDecoder;
+        var s = dec.decode(data);
+        s = s.replace(/\r/g,''); //keep only \n as linebreak
+        var lines = s.split('\n');
+
+        if(lines.length > 0){
+            lines[0] = this.restOfLine + lines[0];
+        }
+
+        console.error(data.toString());
+
+		for(var i = 0; i<lines.length - 1; i++){
+            const j = JSON.parse(lines[i]);
+            // this.debugRuntime.handleJson(j);
+            console.error("Json:", j);
+            this.debugRuntime.handleJson2(j);
+        }
+        if(lines.length > 0){
+            this.restOfLine = lines[lines.length - 1];
+        }
+    };
+}
+
+

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,6 +19,7 @@ export class JsonServer {
     public server: net.Server;
     public restOfLine: string = "";
     public debugRuntime: DebugRuntime;
+    public socket: net.Socket;
     
     async makeServer(debugRuntime: DebugRuntime, host: string = '127.0.0.1', port: number = 0) {
         this.debugRuntime = debugRuntime;
@@ -33,15 +34,19 @@ export class JsonServer {
                 this.handleData(data);
             });
 
-
+            _this.socket = sock;
         });
+
         const serverReady = new Subject();
         this.server.listen(0, this.host, function () {
             serverReady.notify();
         });
 
+        // this.socket.on('data', this.handleData);
+
         await serverReady.wait(1000);
 
+        // const address = this.socket.address();
         const address = this.server.address();
         if (typeof address === 'string' || address === undefined) {
             this.port = 0;

--- a/src/server.ts
+++ b/src/server.ts
@@ -29,6 +29,7 @@ export class JsonServer {
             // Add a 'data' event handler to this instance of socket
             sock.on('data', (data) => {
                 // post data to a server so it can be saved and stuff
+                // console.info(data.toString());
                 this.handleData(data);
             });
 
@@ -59,12 +60,12 @@ export class JsonServer {
             lines[0] = this.restOfLine + lines[0];
         }
 
-        console.error(data.toString());
+        // console.error(data.toString());
 
 		for(var i = 0; i<lines.length - 1; i++){
             const j = JSON.parse(lines[i]);
             // this.debugRuntime.handleJson(j);
-            console.error("Json:", j);
+            // console.error("Json:", j);
             this.debugRuntime.handleJson2(j);
         }
         if(lines.length > 0){

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -54,10 +54,10 @@ export async function getRStartupArguments(): Promise<RStartupArguments> {
         rArgs = ['--ess', '--quiet', '--no-save'];
     } else if (platform === "darwin") {
         rpath = config().get<string>("rterm.mac", "");
-        rArgs = ['--ess', '--quiet', '--interactive', '--no-save'];
+        rArgs = ['--ess', '--quiet', '--interactive', '--no-save', '--no-echo'];
     } else if (platform === "linux") {
         rpath = config().get<string>("rterm.linux", "");
-        rArgs = ['--ess', '--quiet', '--interactive', '--no-save'];
+        rArgs = ['--ess', '--quiet', '--interactive', '--no-save', '--no-echo'];
     }
 
     if (rpath === "") {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,6 +3,8 @@ import { window, workspace } from "vscode";
 import path = require("path");
 import fs = require("fs");
 import winreg = require("winreg");
+import { platform } from "os";
+import { RStartupArguments } from './debugProtocolModifications';
 
 export function config() {
     return workspace.getConfiguration("rdebugger");
@@ -27,9 +29,10 @@ function getRfromEnvPath(platform: string) {
     return "";
 }
 
-export async function getRPath() {
+export async function getRStartupArguments(): Promise<RStartupArguments> {
     let rpath: string = "";
     const platform: string = process.platform;
+    let rArgs: string[];
 
     if (platform === "win32") {
         rpath = config().get<string>("rterm.windows", "");
@@ -48,21 +51,32 @@ export async function getRPath() {
                 rpath = "";
             }
         }
+        rArgs = ['--ess', '--quiet', '--no-save'];
     } else if (platform === "darwin") {
         rpath = config().get<string>("rterm.mac", "");
+        rArgs = ['--ess', '--quiet', '--interactive', '--no-save'];
     } else if (platform === "linux") {
         rpath = config().get<string>("rterm.linux", "");
+        rArgs = ['--ess', '--quiet', '--interactive', '--no-save'];
     }
 
     if (rpath === "") {
         rpath = getRfromEnvPath(platform);
+        rArgs = ['--ess', '--quiet', '--interactive', '--no-save'];
     }
+    const ret: RStartupArguments = {
+        path: rpath,
+        args: rArgs
+    };
+
     if (rpath !== "") {
-        return rpath;
+        return ret;
+    } else{
+        window.showErrorMessage(`${process.platform} can't find R`);
+        return ret;
     }
-    window.showErrorMessage(`${process.platform} can't find R`);
-    return "";
 }
+
 
 export function escapeForRegex(text: string): string {
   return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -54,10 +54,10 @@ export async function getRStartupArguments(): Promise<RStartupArguments> {
         rArgs = ['--ess', '--quiet', '--no-save'];
     } else if (platform === "darwin") {
         rpath = config().get<string>("rterm.mac", "");
-        rArgs = ['--ess', '--quiet', '--interactive', '--no-save', '--no-echo'];
+        rArgs = ['--quiet', '--interactive', '--no-save'];
     } else if (platform === "linux") {
         rpath = config().get<string>("rterm.linux", "");
-        rArgs = ['--ess', '--quiet', '--interactive', '--no-save', '--no-echo'];
+        rArgs = ['--quiet', '--interactive', '--no-save'];
     }
 
     if (rpath === "") {

--- a/test/R/objects.R
+++ b/test/R/objects.R
@@ -3,6 +3,10 @@ options(vsc.trySilent = FALSE)
 options(error = traceback)
 
 options(vsc.matricesByRow = FALSE)
+options(vsc.dataFramesByRow = TRUE)
+
+# options(vsc.showCustomAttributes = FALSE)
+# options(vsc.showAttributes = FALSE)
 
 # trace(.vsc.setVariable, tracer=browser)
 

--- a/test/R/objects.R
+++ b/test/R/objects.R
@@ -2,6 +2,8 @@ options(vsc.trySilent = FALSE)
 
 options(error = traceback)
 
+options(vsc.matricesByRow = FALSE)
+
 # trace(.vsc.setVariable, tracer=browser)
 
 # NULL
@@ -110,3 +112,4 @@ main <- function() {
   fun(1, a = 1, b = x, y = l)
   browser()
 }
+

--- a/test/R/test.R
+++ b/test/R/test.R
@@ -35,4 +35,4 @@ main <- function(){
   foo(2,3)
 }
 
-
+main()

--- a/test/R/test2.R
+++ b/test/R/test2.R
@@ -1,0 +1,31 @@
+
+gen_data <- function(n) {
+  x <- rnorm(n)
+  y <- 2 * x
+  out <- data.frame(x = x, y = x)
+  out
+}
+
+calc_stats <- function(x, na.rm = TRUE) {
+  qs <- quantile(x, c(0, 0.25, 0.5, 0.75, 1), na.rm = na.rm, names = FALSE)
+  data.frame(
+    mean = mean(x, na.rm = na.rm),
+    sd = sd(x, na.rm = TRUE),
+    min = qs[[1]],
+    q25 = qs[[2]],
+    median = qs[[3]],
+    q75 = qs[[4]],
+    max = qs[[5]]
+  )
+}
+
+main <- function() {
+  xy_data <- gen_data(100)  ###
+  lm_obj <- lm(y ~ x, data = xy_data)
+  beta <- coef(lm_obj)
+  stats <- lapply(names(xy_data), function(name) {
+    cbind(name, calc_stats(xy_data[[name]])) ###
+  })
+  print(beta)
+  print(stats)
+}


### PR DESCRIPTION
This PR adds functionality to receive responses/events from R through a tcp socket. Keeps stdout cleaner and does not interfere with normal script output.

Also adds a (commented out) function to dispatch requests via socket. This is currently used though, since the handling of e.g. step requests is done by VS-Code and not in R itself.