### PR TITLE
Add option to show all, filtered or no stdout

### DIFF
--- a/package.json
+++ b/package.json
@@ -199,12 +199,18 @@
         "rdebugger.startupTimeout": {
           "type": "number",
           "default": 2000,
-          "description": "The maximum time in ms that is waited for R to startup"
+          "description": "The maximum time in ms that is waited for R to startup."
         },
-        "rdebugger.printEverything": {
+        "rdebugger.printStderr": {
           "type": "boolean",
-          "default": false,
-          "description": "For debugging the debugger: Whether to show everything printed to stdoutor stderr by the child process. Recommended to set debug.console.wordWrap=false"
+          "default": true,
+          "description": "Whether to print stderr to the debug console."
+        },
+        "rdebugger.printStdout": {
+          "type": "string",
+          "enum": ["all", "filtered", "nothing"],
+          "default": "filtered",
+          "description": "How much of stdout to print to the debug console."
         }
       }
     }


### PR DESCRIPTION
Adds an option `printStdout` to configure how stdout is printed to the debug console:
* **all**: Everything, including the prompt and messages printed by `browser`
* **filtered**: The extension tries to filter out irrelevant stuff
* **nothing**: Nothing from Stdout is printed to the debug console. Only text printed by `.vsc.cat` and `.vsc.print` (which are configured to overwrite `cat` and `print` by default) is shown in the debug console.

Adds on option `printStderr` to configure if stderr is printed to the debug console (true/false)