### PR TITLE
Improve terminate/disconnect process

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -115,5 +115,6 @@ If no values are set, the defaults listed below are used.
 * `"vsc.showEvaluateName" = TRUE`: Whether to include an evaluate name to copy variables to another R session. Can be disabled for performance reasons when working with large variables/lists/vectors.
 * `"vsc.showInternalFrames" = FALSE`: Whether to show the frames on the bottom of the stack that belong to the R package 
 * `"vsc.supportSetVariable" = TRUE`: Whether to enable support for settings the value of variables from the variables window
+* `"vsc.supportTerminateRequest" = TRUE`: Whether to try and exit only the main function/file when stop (Shift+F5) is used, preserving the R session itself.
 * `"vsc.trySilent" = TRUE`: Whether to hide error messages that are expected and caught by the R package
 * `"vsc.verboseVarInfos" = FALSE`: Whether to print debug info when retrieving info about variables

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "r-debugger",
-	"version": "0.1.1",
+	"version": "0.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -1782,6 +1782,11 @@
 			"requires": {
 				"is-number": "^7.0.0"
 			}
+		},
+		"tree-kill": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+			"integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="
 		},
 		"tslib": {
 			"version": "1.11.1",

--- a/package.json
+++ b/package.json
@@ -193,12 +193,12 @@
         },
         "rdebugger.rterm.mac": {
           "type": "string",
-          "default": "/usr/local/bin/R",
+          "default": "",
           "description": "R path for macOS."
         },
         "rdebugger.rterm.linux": {
           "type": "string",
-          "default": "/usr/bin/R",
+          "default": "",
           "description": "R path for Linux."
         },
         "rdebugger.startupTimeout": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   ],
   "main": "./out/extension.js",
   "contributes": {
-    "commands":[
+    "commands": [
       {
         "command": "rdebugger.updateRPackage",
         "title": "Update or install the required R Package",
@@ -245,6 +245,7 @@
     "loglevel": "^1.7.0",
     "net": "^1.0.2",
     "semver": "^7.3.2",
+    "tree-kill": "^1.2.2",
     "vscode-debugadapter": "^1.40.0",
     "winreg": "^1.2.4"
   }

--- a/src/debugRuntime.ts
+++ b/src/debugRuntime.ts
@@ -172,10 +172,11 @@ export class DebugRuntime extends EventEmitter {
 			logger.info("R Session ready");
 		} else {
 			const rPath = rStartupArguments.path;
-			const message = 'R path not working:\n' + rPath;
+			const message = 'R path not working:\n' + rPath + '\n(Can be changed in setting rdebugger.rterm.XXX)';
 			await this.abortInitializeRequest(response, message);
 			this.writeOutput('R not responding within ' + this.startupTimeout + 'ms!', true, true);
 			this.writeOutput('R path:\n' + rPath, true, true);
+			this.writeOutput('If R is installed but in a different path, please adjust the setting rdebugger.rterm.windows/mac/linux.');
 			return false;
 		}
 

--- a/src/debugSession.ts
+++ b/src/debugSession.ts
@@ -17,7 +17,7 @@ import { Response } from 'vscode-debugadapter/lib/messages';
 import { ProtocolServer } from 'vscode-debugadapter/lib/protocol';
 import { DebugProtocol } from 'vscode-debugprotocol';
 import { SourceArguments, InitializeRequest, ContinueArguments, StrictDebugConfiguration, ResponseWithBody, InitializeRequestArguments, ContinueRequest } from './debugProtocolModifications';
-import { config, getVSCodePackageVersion } from './utils';
+import { config, getVSCodePackageVersion, timeout } from './utils';
 
 import * as log from 'loglevel';
 const logger = log.getLogger("DebugSession");
@@ -29,6 +29,8 @@ export class DebugSession extends ProtocolServer {
 
 	// a runtime (or debugger)
     private _runtime: DebugRuntime;
+
+    private disconnectTimeout: number = 1000;
 
 
     sendResponse(response: DebugProtocol.Response): void {
@@ -142,9 +144,18 @@ export class DebugSession extends ProtocolServer {
                         sendResponse = false;
                     }
                     break;
-                // case 'disconnect':
-                //     this._runtime.terminateFromPrompt();
-                //     break;
+                case 'disconnect':
+                    setTimeout(()=>{
+                        console.log('killing R...');
+                        this._runtime.killR();
+                    }, this.disconnectTimeout);
+                    // timeout(this.disconnectTimeout).then(
+                    //     () => {
+                    //     }
+                    // );
+                    dispatchToR = true;
+                    sendResponse = false;
+                    break;
                 // case 'terminate':
                 //     this._runtime.terminateFromPrompt();
                 //     break;

--- a/src/debugSession.ts
+++ b/src/debugSession.ts
@@ -142,12 +142,12 @@ export class DebugSession extends ProtocolServer {
                         sendResponse = false;
                     }
                     break;
-                case 'disconnect':
-                    this._runtime.terminateFromPrompt();
-                    break;
-                case 'terminate':
-                    this._runtime.terminateFromPrompt();
-                    break;
+                // case 'disconnect':
+                //     this._runtime.terminateFromPrompt();
+                //     break;
+                // case 'terminate':
+                //     this._runtime.terminateFromPrompt();
+                //     break;
                 // case 'restart':
                     // this._runtime.returnToPrompt();
                 //     break;
@@ -166,12 +166,12 @@ export class DebugSession extends ProtocolServer {
                 case 'pause':
                     response.success = false;
                     break;
-                case 'source':
-                    const srcbody = request.arguments.source.srcbody;
-                    if(srcbody){
-                        response.body = {content: srcbody};
-                    }
-                    break;
+                // case 'source':
+                //     const srcbody = request.arguments.source.srcbody;
+                //     if(srcbody){
+                //         response.body = {content: srcbody};
+                //     }
+                //     break;
                 default:
                     // request not handled here -> send to R
                     dispatchToR = true;

--- a/src/rSession.ts
+++ b/src/rSession.ts
@@ -8,6 +8,7 @@ import { makeFunctionCall, anyRArgs } from './rUtils';
 import { config, getPortNumber } from './utils';
 import * as net from 'net';
 const { Subject } = require('await-notify');
+const kill = require('tree-kill');
 
 import * as log from 'loglevel';
 const logger = log.getLogger("RSession");
@@ -152,7 +153,10 @@ export class RSession {
 
     // Kill the child process
     public killChildProcess(){
-        this.cp.kill('SIGKILL');
+        console.log('sending sigkill...');
+        // this.cp.kill();
+        kill(this.cp.pid, 'SIGKILL');
+        console.log('sent sigkill');
     }
 
     public handleData(data: Buffer, from: DataSource){

--- a/test/R/.Rprofile
+++ b/test/R/.Rprofile
@@ -1,2 +1,4 @@
 
 # .libPaths('./lib')
+
+# options(vsc.supportTerminateRequest = FALSE)

--- a/test/R/.vscode/launch.json
+++ b/test/R/.vscode/launch.json
@@ -19,7 +19,7 @@
             "debugMode": "file",
             "workingDirectory": "${workspaceFolder}",
             "file": "${file}",
-            "allowGlobalDebugging": true
+            "allowGlobalDebugging": false
         },
         {
             "type": "R-Debugger",
@@ -29,6 +29,15 @@
             "workingDirectory": "${fileDirname}",
             "file": "${file}",
             "mainFunction": "main",
+            "allowGlobalDebugging": true
+        },
+        {
+            "type": "R-Debugger",
+            "request": "launch",
+            "name": "Debug Shiny App",
+            "debugMode": "file",
+            "workingDirectory": "${workspaceFolder}/app",
+            "file": "${workspaceFolder}/app/entrypoint.R",
             "allowGlobalDebugging": false
         }
     ]

--- a/test/R/.vscode/settings.json
+++ b/test/R/.vscode/settings.json
@@ -5,6 +5,6 @@
     // "rdebugger.printStdout": "all",
     // "rdebugger.printSinkSocket": "all",
     // "rdebugger.logLevelRSession": "debug",
-    // "rdebugger.logLevelDebugSession": "none",
+    // "rdebugger.logLevelSession": "debug",
     // "rdebugger.rterm.windows": "\"C:\\Program Files\\R\\R-4.0.2\\bin\\x64\\R.exe\""
 }

--- a/test/R/app/entrypoint.R
+++ b/test/R/app/entrypoint.R
@@ -1,0 +1,4 @@
+
+# host: 0.0.0.0 (https://stackoverflow.com/a/59182290/6662425)
+# shiny::runApp('.', launch.browser=FALSE, port=8888, host='0.0.0.0')
+shiny::runExample("01_hello")

--- a/test/R/objects.R
+++ b/test/R/objects.R
@@ -32,6 +32,13 @@ df2 <- data.frame(id = 1:5, x = rnorm(5), y = rnorm(5))
 # factor
 fctr <- as.factor(c("a", "b", "c", "c", "d"))
 
+if(TRUE){
+  print(
+    1
+  )
+  print(2)
+}
+
 # matrix
 mat0 <- matrix(numeric())
 mat1 <- matrix(1:10, nrow = 1)
@@ -43,9 +50,12 @@ nmat2 <- matrix(1:10, ncol = 1, dimnames = list(letters[1:10], "x"))
 nmat3 <- matrix(rnorm(20), nrow = 4, dimnames = list(letters[1:4], letters[1:5]))
 
 # array
+print(1)
 arr0 <- array(numeric())
+
 arr1 <- array(1:10, c(10, 1, 1))
 arr2 <- array(1:10, c(1, 10, 1))
+print(2)
 arr3 <- array(1:10, c(1, 1, 10))
 arr4 <- array(1:12, c(2,3,2))
 
@@ -110,8 +120,12 @@ s5 <- TRUE
 s6 <- charToRaw("h")
 
 # ...
-fun <- function(x, y, ...) {
-  browser()
+fun <- function(x, y=x, ...) {
+  print('2')
+  # print('3')
+  base::cat(list(1,2,3)) # error
+  print('4')
+  x*y
 }
 
 # active bindings
@@ -121,7 +135,8 @@ makeActiveBinding("x", function() rnorm(1), env1)
 main <- function() {
   print("testing objects")
   print('asdf')
-  fun(1, 2, 4)
+  v <- 1:10
+  w <- sapply(v, fun)
   print('q  wer')
 }
 


### PR DESCRIPTION
Fixes https://github.com/ManuelHentschel/VSCode-R-Debugger/issues/79
Improves on https://github.com/ManuelHentschel/VSCode-R-Debugger/issues/77 and https://github.com/ManuelHentschel/VSCode-R-Debugger/issues/76

The two-step teminate/disconnect-process can be disabled by setting `options(vsc.supportTerminateRequest = FALSE)`, which speeds up the disconnect-process e.g. when stopping an unresponsive R process (as is the case for shiny apps).