### PR TITLE
Improve package debugging

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,22 +118,27 @@
               "overwritePrint": {
                 "type": "boolean",
                 "default": true,
-                "description": "Whether to write a new print() function to .GlobalEnv (direct calls to base::print are not affected)."
+                "description": "Whether to attach a modified print() function (direct calls to base::print are not affected)."
+              },
+              "overwriteMessage": {
+                "type": "boolean",
+                "default": true,
+                "description": "Whether to attach a modified message() function (direct calls to base::message are not affected)."
               },
               "overwriteCat": {
                 "type": "boolean",
                 "default": true,
-                "description": "Whether to write a new cat() function to .GlobalEnv (direct calls to base::cat are not affected)."
+                "description": "Whether to attach a modified cat() function (direct calls to base::cat are not affected)."
               },
               "overwriteSource": {
                 "type": "boolean",
                 "default": true,
-                "description": "Whether to write a new source() function to .GlobalEnv (direct calls to base::source are not affected)."
+                "description": "Whether to attach a modified source() function (direct calls to base::source are not affected)."
               },
               "setBreakpointsInPackages": {
                 "type": "boolean",
                 "default": false,
-                "description": "Whether to enable breakpoints in packages. Can impact performance if set to true."
+                "description": "Whether to enable breakpoints in exported functions from ALL packages. Usually, `debuggedPackages` is preferred."
               },
               "includePackageScopes": {
                 "type": "boolean",
@@ -141,12 +146,17 @@
                 "description": "Set to true to show package scopes in the variable window."
               },
               "packagesBeforeLaunch": {
+                "type": "DEPRECATED ENTRY! Use `debuggedPackages` instead.",
+                "default": "DEPRECATED ENTRY! Use `debuggedPackages` instead.",
+                "description": "DEPRECATED ENTRY! Use `debuggedPackages` instead."
+              },
+              "debuggedPackages": {
                 "type": "array",
                 "items": {
                   "type": "string"
                 },
                 "default": [],
-                "description": "Packages to be loaded before launching the R script."
+                "description": "Packages to be debugged. Are loaded before launching the R script/file/function, and can contain breakpoints."
               }
             }
           }

--- a/src/debugProtocolModifications.ts
+++ b/src/debugProtocolModifications.ts
@@ -39,10 +39,11 @@ export interface DebugConfiguration extends VsCode.DebugConfiguration {
     // specify how to debug (optional)
     includePackageScopes?: boolean;
     setBreakpointsInPackages?: boolean;
-    packagesBeforeLaunch?: string[];
+    debuggedPackages?: string[];
     assignToAns?: boolean;
     overwritePrint?: boolean;
     overwriteCat?: boolean;
+    overwriteMessage?: boolean;
     overwriteSource?: boolean;
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -64,7 +64,7 @@ class DebugConfigurationProvider implements vscode.DebugConfigurationProvider {
 		if(!config.file){
 			config.file = '${file}';
 		}
-		if(!config.function){
+		if(!config.mainFunction){
 			config.mainFunction = 'main';
 		}
 

--- a/test/R/.vscode/launch.json
+++ b/test/R/.vscode/launch.json
@@ -28,8 +28,11 @@
             "debugMode": "function",
             "workingDirectory": "${fileDirname}",
             "file": "${file}",
-            "mainFunction": "main",
-            "allowGlobalDebugging": false
+            // "file": "asdfasdf",
+            // "mainFunction": "main",
+            "allowGlobalDebugging": false,
+            "setBreakpointsInPackages": false,
+            // "packagesBeforeLaunch": ["asdf"]
         },
         {
             "type": "R-Debugger",


### PR DESCRIPTION
Support for https://github.com/ManuelHentschel/vscDebugger/pull/108:

> Improves package debugging:
> * Sets breakpoints only in specified packages (faster than searching all packages)
> * Sets breakpoints in non-exported functions
> * Introduces `.vsc.message()` to overwrite `base::message()`
> * Overwrites `cat`, `print`, `message` in specified packages. For this to work, these functions must be assigned somewhere in the > package:
> ``` r
> print <- print
> cat <- cat
> message <- message
> ```