### PR TITLE
Use a script to install vscDebugger

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -1,0 +1,8 @@
+repos <- getOption("repos")
+if (is.null(repos) || identical(repos, c(CRAN = "@CRAN@"))) {
+  repos <- c(CRAN = "https://cloud.r-project.org/")
+}
+
+url <- commandArgs(trailingOnly = TRUE)[[1]]
+install.packages(c("jsonlite", "R6"), repos = repos)
+install.packages(url, repos = NULL)

--- a/R/install.R
+++ b/R/install.R
@@ -1,8 +1,8 @@
 repos <- getOption("repos")
 if (is.null(repos) || identical(repos, c(CRAN = "@CRAN@"))) {
-  repos <- c(CRAN = "https://cloud.r-project.org/")
+  options(repos = c(CRAN = "https://cloud.r-project.org/"))
 }
 
 url <- commandArgs(trailingOnly = TRUE)[[1]]
-install.packages(c("jsonlite", "R6"), repos = repos)
-install.packages(url, repos = NULL)
+install.packages("remotes")
+remotes::install_url(url, dependencies = TRUE)

--- a/R/install.R
+++ b/R/install.R
@@ -3,6 +3,7 @@ if (is.null(repos) || identical(repos, c(CRAN = "@CRAN@"))) {
   options(repos = c(CRAN = "https://cloud.r-project.org/"))
 }
 
+install.packages(c("jsonlite", "R6"))
+
 url <- commandArgs(trailingOnly = TRUE)[[1]]
-install.packages("remotes")
-remotes::install_url(url, dependencies = TRUE)
+install.packages(url, repos = NULL)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,7 +43,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	}
 
 	context.subscriptions.push(
-		vscode.commands.registerCommand('rdebugger.updateRPackage', updateRPackage)
+		vscode.commands.registerCommand('rdebugger.updateRPackage', () => updateRPackage(context.extensionPath))
 	);
 }
 

--- a/src/installRPackage.ts
+++ b/src/installRPackage.ts
@@ -3,7 +3,7 @@ import { getRDownloadLink, getRStartupArguments, config, getRequiredRPackageVers
 import * as vscode from 'vscode';
 import { RSession } from './rSession';
 import { write } from 'fs';
-
+import { join } from 'path';
 import Subject = require('await-notify');
 import semver = require('semver');
 
@@ -17,20 +17,13 @@ export interface PackageVersionInfo {
 export type VersionCheckLevel = "none"|"required"|"recommended";
 
 
-export async function updateRPackage(packageName:string = 'vscDebugger') {
+export async function updateRPackage(extensionPath: string, packageName:string = 'vscDebugger') {
     vscode.window.showInformationMessage('Installing R Packages...');
     const url = getRDownloadLink(packageName);
     const rPath = (await getRStartupArguments()).path;
     const terminal = vscode.window.createTerminal('InstallRPackage');
     terminal.show();
-    terminal.sendText(
-        rPath +
-        " --vanilla" +
-        " --silent" +
-        " -e \"install.packages('" + url + "', repos=NULL)\"" +
-        " -e \"install.packages('jsonlite', repos='http://cran.r-project.org')\"" +
-        " -e \"install.packages('R6', repos='http://cran.r-project.org')\""
-    );
+    terminal.sendText(`${rPath} --no-restore --quiet -f "${join(extensionPath, 'R', 'install.R')}" --args "${url}"`);
 }
 
 export function explainRPackage(writeOutput: (text: string)=>void, message: string = ""){


### PR DESCRIPTION
Closes #108 

This PR switches to `R/install.R` for the installation of vscDebugger. It makes improvements in the following aspects:

* Respects user profile by replacing the command argument `--vanilla` (ignores user profile) to `--no-restore` only.
* Respects user settings of chosen CRAN mirror. If the user specifies CRAN mirror then it is respected. Otherwise, the RStudio Cloud mirror is used that performs "automatic redirection to servers worldwide".
* It installs `jsonlite` and `R6` together so that they resolve dependencies together.