### PR TITLE
Auto publish and hotfix in vscDebugger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,3 +50,16 @@ jobs:
           prerelease: false
           draft: false 
 
+  publish:
+    name: Publish
+    timeout-minutes: 30
+    needs: release # just to make sure that vscDebugger binaries are available
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: npm install
+      - uses: lannonbr/vsce-action@master
+        with:
+          args: "publish -p $VSCE_TOKEN"
+        env:
+          VSCE_TOKEN: ${{ secrets.VSCE_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "r-debugger",
   "displayName": "R Debugger",
   "description": "R Debugger for VS Code",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "publisher": "RDebugger",
   "license": "MIT",
   "author": {
@@ -11,7 +11,7 @@
   "rPackageInfo": {
     "name": "vscDebugger",
     "required": "0.4.0",
-    "recommended": "0.4.4",
+    "recommended": "0.4.5",
     "warnIfNewer": "0.5.0"
   },
   "repository": {


### PR DESCRIPTION
- Automatically publish releases to marketplace
- Bump version (to trigger hotfix update of vscDebugger)
