### PR TITLE
Implement dataviewer command

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "onLanguage:rd",
     "onLanguage:rmd",
     "onCommand:r.debugger.updateRPackage",
+    "onCommand:r.debugger.showDataViewer",
     "onDebugDynamicConfigurations:R-Debugger",
     "onDebug"
   ],
@@ -49,8 +50,27 @@
         "command": "r.debugger.updateRPackage",
         "title": "Update or install the required R Package",
         "category": "R Debugger"
+      },
+      {
+        "command": "r.debugger.showDataViewer",
+        "title": "Show in data viewer",
+        "enablement": ""
       }
     ],
+    "menus": {
+      "debug/variables/context": [
+        {
+          "command": "r.debugger.showDataViewer",
+          "when": "debugType == 'R-Debugger'"
+        }
+      ],
+      "commandPalette": [
+        {
+          "command": "r.debugger.showDataViewer",
+          "when": "false"
+        }
+      ]
+    },
     "languages": [
       {
         "id": "r",

--- a/package.json
+++ b/package.json
@@ -30,9 +30,6 @@
     "Debuggers"
   ],
   "activationEvents": [
-    "onLanguage:r",
-    "onLanguage:rd",
-    "onLanguage:rmd",
     "onCommand:r.debugger.updateRPackage",
     "onCommand:r.debugger.showDataViewer",
     "onDebugDynamicConfigurations:R-Debugger",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,0 +1,29 @@
+
+import { ShowDataViewerArguments } from './debugProtocolModifications';
+
+import * as vscode from 'vscode';
+
+// Argument provided by vscode when a command is called
+// via the context menu of a variable in the debug panel
+export interface DebugWindowCommandArg {
+    container: {
+        variablesReference: number;
+    };
+    variable: {
+        name: string;
+    }
+}
+
+// Sends a custom request to R to show a variable in the data viewer
+export function showDataViewer(arg: DebugWindowCommandArg){
+    const args: ShowDataViewerArguments = {
+        reason: 'showDataViewer',
+        variablesReference: arg.container.variablesReference,
+        name: arg.variable.name
+    };
+    vscode.debug.activeDebugSession?.customRequest(
+        "custom",
+        args
+    );
+}
+

--- a/src/debugProtocolModifications.ts
+++ b/src/debugProtocolModifications.ts
@@ -195,4 +195,27 @@ export interface ShowingPromptRequest extends CustomRequest {
     }
 }
 
+// Tell R to show the data viewer for a variable
+export interface ShowDataViewerRequest extends CustomRequest {
+    arguments: ShowDataViewerArguments;
+}
+
+export interface ShowDataViewerArguments {
+    reason: "showDataViewer";
+    /** The reference of the variable container. */
+    variablesReference: number;
+    /** The name of the variable in the container. */
+    name: string;
+}
+
+// Argument provided by vscode when a command is called
+// via the context menu of a variable in the debug panel
+export interface DebugWindowCommandArg {
+    container: {
+        variablesReference: number;
+    };
+    variable: {
+        name: string;
+    }
+}
 

--- a/src/debugProtocolModifications.ts
+++ b/src/debugProtocolModifications.ts
@@ -207,15 +207,3 @@ export interface ShowDataViewerArguments {
     /** The name of the variable in the container. */
     name: string;
 }
-
-// Argument provided by vscode when a command is called
-// via the context menu of a variable in the debug panel
-export interface DebugWindowCommandArg {
-    container: {
-        variablesReference: number;
-    };
-    variable: {
-        name: string;
-    }
-}
-

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,9 @@ import {
 	DebugMode, FunctionDebugConfiguration,
 	FileDebugConfiguration, WorkspaceDebugConfiguration,
 	StrictDebugConfiguration,
-	AttachConfiguration
+	AttachConfiguration,
+	ShowDataViewerArguments,
+	DebugWindowCommandArg
 } from './debugProtocolModifications';
 import { updateRPackage } from './installRPackage';
 import { trackTerminals, TerminalHandler } from './terminals';
@@ -21,12 +23,24 @@ import * as path from 'path';
 
 // this method is called when the extension is activated
 export async function activate(context: vscode.ExtensionContext) {
-
+	
 	if(context.globalState.get<boolean>('ignoreDeprecatedConfig', false) !== true){
 		checkSettings().then((ret) => {
 			context.globalState.update('ignoreDeprecatedConfig', ret);
 		});
 	}
+	
+	vscode.commands.registerCommand('r.debugger.showDataViewer', (arg: DebugWindowCommandArg) => {
+		const args: ShowDataViewerArguments = {
+			reason: 'showDataViewer',
+			variablesReference: arg.container.variablesReference,
+			name: arg.variable.name
+		};
+		vscode.debug.activeDebugSession?.customRequest(
+			"custom",
+			args
+		);
+	});
 
 	const rExtension = vscode.extensions.getExtension<RExtension>('ikuyadeu.r');
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,9 +6,7 @@ import {
 	DebugMode, FunctionDebugConfiguration,
 	FileDebugConfiguration, WorkspaceDebugConfiguration,
 	StrictDebugConfiguration,
-	AttachConfiguration,
-	ShowDataViewerArguments,
-	DebugWindowCommandArg
+	AttachConfiguration
 } from './debugProtocolModifications';
 import { updateRPackage } from './installRPackage';
 import { trackTerminals, TerminalHandler } from './terminals';
@@ -16,6 +14,8 @@ import { trackTerminals, TerminalHandler } from './terminals';
 import { RExtension, HelpPanel } from './rExtensionApi';
 
 import { checkSettings } from './utils';
+
+import { DebugWindowCommandArg, showDataViewer } from './commands';
 
 import * as fs from 'fs';
 import * as path from 'path';
@@ -30,18 +30,6 @@ export async function activate(context: vscode.ExtensionContext) {
 		});
 	}
 	
-	vscode.commands.registerCommand('r.debugger.showDataViewer', (arg: DebugWindowCommandArg) => {
-		const args: ShowDataViewerArguments = {
-			reason: 'showDataViewer',
-			variablesReference: arg.container.variablesReference,
-			name: arg.variable.name
-		};
-		vscode.debug.activeDebugSession?.customRequest(
-			"custom",
-			args
-		);
-	});
-
 	const rExtension = vscode.extensions.getExtension<RExtension>('ikuyadeu.r');
 
 	let rHelpPanel: HelpPanel = undefined;
@@ -81,7 +69,10 @@ export async function activate(context: vscode.ExtensionContext) {
 	}
 
 	context.subscriptions.push(
-		vscode.commands.registerCommand('r.debugger.updateRPackage', () => updateRPackage(context.extensionPath))
+		vscode.commands.registerCommand('r.debugger.updateRPackage', () => updateRPackage(context.extensionPath)),
+		vscode.commands.registerCommand('r.debugger.showDataViewer', (arg: DebugWindowCommandArg) => {
+			showDataViewer(arg);
+		})
 	);
 }
 


### PR DESCRIPTION
Fix #123 

Implements a context menu command that opens the selected variable with a data viewer.
By default, `utils::View` is used, this can be overwritten using `options(vsc.dataViewer = MY_VIEWER_FUNCTION)`.

Edit: Currently, no error handling is implemented, I just wanted to get this working for now.
