### PR TITLE
Add launch directory to launch config

### DIFF
--- a/package.json
+++ b/package.json
@@ -202,7 +202,12 @@
               },
               "workingDirectory": {
                 "type": "string",
-                "markdownDescription": "Absolute path to a directory.",
+                "markdownDescription": "Absolute path to a directory. Is switched to using `setwd()` after launching R.",
+                "default": "${workspaceFolder}"
+              },
+              "launchDirectory": {
+                "type": "string",
+                "markdownDescription": "Absolute path to a directory. The R process is launched in this directory.",
                 "default": "${workspaceFolder}"
               },
               "file": {

--- a/src/debugConfig.ts
+++ b/src/debugConfig.ts
@@ -255,6 +255,10 @@ export class DebugConfigurationResolver implements vscode.DebugConfigurationProv
 		} else{
 			strictConfig = null;
 		}
+		
+		// set launchingDirectory to workingDirectory if not specified otherwise:
+		config.launchDirectory ||= config.workingDirectory;
+
 		return strictConfig;
 	}
 }

--- a/src/debugProtocolModifications.ts
+++ b/src/debugProtocolModifications.ts
@@ -67,7 +67,8 @@ export interface LaunchConfiguration extends DebugConfiguration {
     commandLineArgs?: string[];
     env?: {
         [key: string]: string;
-    }
+    };
+    launchDirectory?: string;
 }
 
 export interface FunctionDebugConfiguration extends LaunchConfiguration {

--- a/src/debugRuntime.ts
+++ b/src/debugRuntime.ts
@@ -109,7 +109,7 @@ export class DebugRuntime extends EventEmitter {
 
 		// start R in child process
 		const rStartupArguments  = await getRStartupArguments(this.launchConfig);
-		rStartupArguments.cwd = vscode.workspace.workspaceFolders?.[0].uri.fsPath;
+		rStartupArguments.cwd ||= vscode.workspace.workspaceFolders?.[0].uri.fsPath;
 
 		if(!rStartupArguments.path){
 			const message = 'No R path was found in the settings/path/registry.\n(Can be changed in setting r.rpath.XXX)';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -114,7 +114,11 @@ export function timeout(ms: number): Promise<unknown> {
 }
 
 
-export async function getRStartupArguments(launchConfig: {env?: {[key: string]: string}; commandLineArgs?: string[]} = {}): Promise<RStartupArguments> {
+export async function getRStartupArguments(launchConfig: {
+    env?: {[key: string]: string};
+    commandLineArgs?: string[];
+    launchDirectory?: string;
+} = {}): Promise<RStartupArguments> {
     const platform: string = process.platform;
 
     const rpath = await getRpath(true);
@@ -133,7 +137,7 @@ export async function getRStartupArguments(launchConfig: {env?: {[key: string]: 
     const ret: RStartupArguments = {
         path: rpath,
         args: rArgs,
-        cwd: undefined,
+        cwd: launchConfig.launchDirectory,
         env: launchConfig.env
     };
 


### PR DESCRIPTION
Fix #149 

This PR adds a `launchDirectory` entry to the debug config. This value is used by vscode-r-debugger to launch the R process in the specified directory (and hence read the .Rprofile from there).

Edit: If `launchDirectory` is not specified, the value of `workingDirectory` is used.